### PR TITLE
Corrected mailto: address for TripLink/travel suppliers

### DIFF
--- a/why-concur.html
+++ b/why-concur.html
@@ -122,7 +122,7 @@ layout: default
                     <div class="col-md-6">
                         <h2>Travel Suppliers</h2>
                         <p>Deliver complete visibility to your corporate clients with automatic itinerary and receipt integration by becoming a TripLink partner. Extend your value as a preferred supplier and acquire new users while saving costs. Also extend the benefits of managed travel programs, like negotiated rates and policy compliance, to all bookings that take place on TripLink supplier sites</p><br>
-                        <a class="btn-u btn-u-blue one-page-btn" href="mailto:bizdev@concur.com"><i class="fa fa-envelope"></i> Contact Us</a>
+                        <a class="btn-u btn-u-blue one-page-btn" href="mailto:connect@concur.com"><i class="fa fa-envelope"></i> Contact Us</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
The business development email address for travel and TripLink suppliers is connect@concur.com.