### PR TITLE
Update expense-allocations.markdown

### DIFF
--- a/api-reference/expense/allocations/expense-allocations.markdown
+++ b/api-reference/expense/allocations/expense-allocations.markdown
@@ -37,7 +37,7 @@ This resource can be used to retrieve information about the allocations that are
 
 
 ## <a name="getID"></a>Retrieve a single allocation by ID
-    GET /expense/allocations{id}
+    GET /expense/allocations/{id}
 
 
 ### Parameters


### PR DESCRIPTION
Missing forward slash on GET /expense/allocations call