### PR TITLE
Update breadcrumb Home link to use site.baseurl

### DIFF
--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -3,7 +3,7 @@
         <div class="container">
             <h1 class="pull-left">{{ page.title }}</h1>
             <ol class="pull-right breadcrumb">
-                <li><a href="/">Home</a></li>
+                <li><a href="{{ site.baseurl }}/">Home</a></li>
                 {% assign crumbs = page.url | split: '/' %}
                 {% assign crumbs_total = crumbs | size | minus: 1 %}
                 {% for crumb in crumbs offset: 1 %}


### PR DESCRIPTION
It was hard-coded to use / instead of respecting the base url.  The trailing slash is appended within the href.