### PR TITLE
toggle disable on state dropdown field

### DIFF
--- a/newsletter-request.html
+++ b/newsletter-request.html
@@ -62,6 +62,10 @@ title: Developer Newsletter Signup
 </div><!--/col-md-12-->
 
 <script>
+  $("#newsletterRequest").change(function(){
+    ($("#country").val() !== "US") ? $("#state").attr("disabled", true) && $("#state").val("") : $("#state").attr("disabled", false);
+  });
+
   $("#newsletterRequest").validate({
     // Rules for form validation
     rules: {


### PR DESCRIPTION
Disables the 'state' select field on the newsletter signup form when the US is not selected.