### PR TITLE
separate acconect utility and web test tool markdown files

### DIFF
--- a/tools-support/tools/acconnect-utility.markdown
+++ b/tools-support/tools/acconnect-utility.markdown
@@ -3,6 +3,8 @@ title: acconnect Utility
 layout: reference
 ---
 
+### acconect Utility
+
 acconnect is a command-line tool that obtains a request token for the specified user by using the App Center flow.
 
 #### Requirements:
@@ -46,4 +48,3 @@ acconnect.exe VJbNf8skImcf79QOV2Zfz8 M6nNN433aaXh9W4kNJQVP85DpPd3JYGV EXPRPT joh
 ``
 
 [1]:{{ site.baseurl }}/tools-support/tools-files/acconnect.zip
-

--- a/tools-support/tools/index.markdown
+++ b/tools-support/tools/index.markdown
@@ -1,21 +1,7 @@
 ---
-title: Tools
+title: Web Test Tool
 layout: reference
 ---
-
-### acconnect Utility
-The acconnect utility is a Windows command-line tool that obtains a request token by simulating the App Center flow.
-
-**Requirements:**
-
-* For Windows users, Windows XP or later Windows operating System.
-* For Mac users, a Windows VM such as Parallels Desktop.
-* You must be an administrator on the local computer to run acconnect.
-
-[acconnect utility help](/tools-support/tools/acconnect-utility.html)  
-
-[acconnect utility](/tools-support/tools-files/acconnect.zip) (ZIP File)
-
 
 ### Web Test Tool
 


### PR DESCRIPTION
Updated the markdown to remove repetition in tools section, renamed the markdown titles to preserve using the left-nav as table of contents.

Is this an okay alternative to one file? (It seemed a little more user friendly to me this way!)