### PR TITLE
Update footer copyright date from 2015 to 2016...

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -73,7 +73,7 @@
                 <div class="row">
                     <div class="col-md-8">
                         <p>
-                            2015 &copy; All Rights Reserved.
+                            2016 &copy; All Rights Reserved.
                            <a href="https://www.concur.com/en-us/privacy-policy">Privacy Policy</a> | <a href="{{ site.baseurl }}/Terms-of-Use.html">Terms of Use</a> | <a href="{{ site.baseurl }}/tools-support/reference/deprecation-policy.html">API Deprecation Policy</a></a>
                         </p>
                     </div>


### PR DESCRIPTION
...though can't we write a script to automatically use the current year so this doesn't have to be maintained?