### PR TITLE
local storage to preserve token

### DIFF
--- a/_layouts/reference.html
+++ b/_layouts/reference.html
@@ -23,3 +23,11 @@ layout: default
 
     </div><!--/container-->
     <!--=== End Content Part ===-->
+    <script>
+      $(document).ready(function(){
+        localStorage.api_key ? $('#input_apiKey').val(localStorage.api_key) : null;
+      });
+      $('#input_apiKey').change(function(){
+          localStorage.setItem('api_key', $('#input_apiKey').val());
+      });
+    </script>


### PR DESCRIPTION
Part of the feedback we received on Swagger 2.0 was frustration at have to enter your API key repeatedly. We could use local storage to preserve it for the user.