### PR TITLE
update 'reference'

### DIFF
--- a/blog/_posts/2016-03-18-quick-expense-api-payment-type.markdown
+++ b/blog/_posts/2016-03-18-quick-expense-api-payment-type.markdown
@@ -7,6 +7,7 @@ tags:
     - Payment-Type
 references:
     - url: /api-explorer/v3-0/QuickExpenses.html
+      link: Quick Expenses
 author: Sarra Loew
 ---
 


### PR DESCRIPTION
Update 'reference' on blogpost to fix view.

https://developer.concur.com/blog/2016/03/18/quick-expense-api-payment-type.html
