### PR TITLE
'DateTime' should be Local Time

### DIFF
--- a/api-reference/expense/receipts/index.markdown
+++ b/api-reference/expense/receipts/index.markdown
@@ -15,7 +15,7 @@ The Receipts resource represents receipts that can be posted to Concur by a prov
 
 **Notes:**  
 
-* Receipts currently can't be Posted to users whose data is hosted in Concur's EU datacenter.  Only users whose data is hosted in the US datacenter can receive ereceipts.  
+* Receipts currently can't be Posted to users whose data is hosted in Concur's EU datacenter.  Only users whose data is hosted in the US datacenter can receive e-receipts.  
 * The Receipt Service only accepts receipts that are up to 6 months old. Older receipts will not be accepted.
 * Unlike all the other Concur API endpoints, the e-receipt requires the Concur Platform team to configure your sandbox to enable access. You can send a request using the [Sandbox Configuration Assistance form](/tools-support/sandbox-configuration-assistance.html). Please include the name of the Concur representative you're working with in the details section of the form.
 
@@ -65,7 +65,7 @@ Name | Type | Format | Description
 `Merchant`	|	`Merchant`	|	-	|	**Required** The parent element for information about the provider who is posting the receipt.
 `PaymentCard`	|	`PaymentCard`	|	-	|	The parent element for the credit card used for payment. This element is required when the FormofPaymentCode value is CCARD.
 `RideDetail`	|	`RideDetail`	|	-	|	The details of a hired ride. This element is required when the Type value is Ride.
-`TransactionDateTime`	|	`DateTime`	|	-	|	**Required** The date and time when the transaction happened (in Coordinated Universal Time, aka UTC). Format: YYYY-MM-DDThh:mm
+`TransactionDateTime`	|	`DateTime`	|	-	|	**Required** The date and time when the transaction happened (in Local Time). Format: YYYY-MM-DDThh:mm
 `Type`	|	`string`	|	-	|	**Required** The type of receipt. Possible values: General, Ride, Hotel		
 
 ### <a name="customfield"></a>Custom Field	
@@ -87,7 +87,7 @@ Name | Type | Format | Description
 Name | Type | Format | Description
 -----|------|--------|------------						
 `Amount`	|	`Decimal`	|	-	|	**Required** The total charged amount for the line item. Range: -922,337,203,685,477 to 922,337,203,685,477
-`Date`	|	`DateTime`	|	-	|	The date and time when the line item was charged (in Coordinated Universal Time, aka UTC). Format: YYYY-MM-DDThh:mm
+`Date`	|	`DateTime`	|	-	|	The date and time when the line item was charged (in Local Time). Format: YYYY-MM-DDThh:mm
 `Description`	|	`string`	|	-	|	**Required** The item's description. Maximum length: 100 characters
 `Description2`	|	`string`	|	-	|	Additional details about the item. In the receipt image, the secondary description appears on the line following the primary description. Maximum length: 32 characters
 `Quantity`	|	`Int32`	|	-	|	The quantity of units. Format: Any positive number
@@ -102,8 +102,8 @@ Name | Type | Format | Description
 Name | Type | Format | Description
 -----|------|--------|------------						
 `AverageDailyRoomRate`	|	`Decimal`	|	-	|	**Required** The sum of the room rate for each night stayed, divided by the number of nights stayed. Range: -922,337,203,685,477 to 922,337,203,685,477
-`CheckinDateTime`	|	`DateTime`	|	-	|	**Required** The check-in date and time (in Coordinated Universal Time, aka UTC). Format: YYYY-MM-DDThh:mm
-`CheckoutDateTime`	|	`DateTime`	|	-	|	**Required** The check-out date and time (in Coordinated Universal Time, aka UTC). Format: YYYY-MM-DDThh:mm
+`CheckinDateTime`	|	`DateTime`	|	-	|	**Required** The check-in date and time (in Local Time). Format: YYYY-MM-DDThh:mm
+`CheckoutDateTime`	|	`DateTime`	|	-	|	**Required** The check-out date and time (in Local Time). Format: YYYY-MM-DDThh:mm
 `ConfirmationNumber`	|	`string`	|	-	|	The confirmation number for the booking. Maximum length: 32 characters
 `GNR`	|	`string`	|	-	|	The Guest Name Record (GNR) for the stay. Maximum length: 20 characters
 `LineItems`	|	`Array`	|	[Line Item](#lineitem)	|	The parent element for the line items in the receipt. There is a LineItem child element for each line item.
@@ -164,7 +164,7 @@ Name | Type | Format | Description
 `DriverName`	|	`string`	|	-	|	The name of the driver. Maximum length: 255 characters
 `DropoffLatitude`	|	`Decimal`	|	-	|	The latitude of the ride end location. Range: -90 to 90
 `DropoffLongitude`	|	`Decimal`	|	-	|	The longitude of the ride end location. Range: -180 to 180
-`EndDateTime`	|	`DateTime`	|	-	|	**Required** The ending date and time for the ride. Format: YYYY-MM-DDThh:mm
+`EndDateTime`	|	`DateTime`	|	-	|	**Required** The ending date and time for the ride (in Local Time). Format: YYYY-MM-DDThh:mm
 `LineItems`	|	`Array`	|	[Line Item](#lineitem)	|	The parent element for the line items in the receipt. There is a LineItem child element for each line item.
-`StartDateTime`	|	`DateTime`	|	-	|	**Required** The starting date and time for the ride. Format: YYYY-MM-DDThh:mm
+`StartDateTime`	|	`DateTime`	|	-	|	**Required** The starting date and time for the ride (in Local Time). Format: YYYY-MM-DDThh:mm
 `VehicleNumber`	|	`string`	|	-	|	The unique identifier for the vehicle. Maximum length: 50 characters


### PR DESCRIPTION
Corrected 'DateTime' descriptions for time zone. Per Expense product management, all DateTime fields should be expressed in the local time where the event occurred, not in UTC.