### PR TITLE
Update sandbox-configuration-assistance.html

### DIFF
--- a/tools-support/sandbox-configuration-assistance.html
+++ b/tools-support/sandbox-configuration-assistance.html
@@ -1,3 +1,6 @@
+
+I suggest we remove this page and direct partner developers to use the forums instead
+
 ---
 layout: page
 title: Sandbox Configuration Assistance


### PR DESCRIPTION
I don't know where this goes when a user fills it out?  I think this link should be removed from the dev portal, and partner developers should be instructed to Post to the forums if they need this type of assistance.