### PR TITLE
userId is not supported by this API

### DIFF
--- a/api-explorer/v3-0/Allocations.swagger2.json
+++ b/api-explorer/v3-0/Allocations.swagger2.json
@@ -66,13 +66,6 @@
             "description": "The unique identifier for the expense itemization.",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "user",
-            "in": "query",
-            "description": "The login ID of the user who owns the allocation. The user must have the Web Services Admin role to use this parameter.",
-            "required": false,
-            "type": "string"
           }
         ],
         "responses": {


### PR DESCRIPTION
Based on our investigation of this API, there is no code to support userId as a query string parameter to filter the results. Therefore, removing this from the swagger definitions.