### PR TITLE
Update reports.markdown

### DIFF
--- a/api-reference/expense/expense-report/reports.markdown
+++ b/api-reference/expense/expense-report/reports.markdown
@@ -220,7 +220,7 @@ Name | Type | Format | Description
 `PaymentStatusCode`	|	`string`	|	-	|	The code for the payment status of the report.
 `PaymentStatusName`	|	`string`	|	-	|	The report's payment status, in the OAuth consumer's language.
 `PersonalAmount`	|	`Decimal`	|	-	|	The total amount of expenses marked as personal. Maximum 23 characters.
-`PolicyID`	|	`string`	|	-	|	The unique identifier of the policy that applies to this report. Maximum 64 characters.
+`PolKey`	|	`string`	|	-	|	The unique identifier of the policy that applies to this report. Maximum 64 characters.
 `ProcessingPaymentDate`	|	`DateTime`	|	-	|	The date that the report completed all approvals and was ready to be extracted for payment.
 `ReceiptsReceived`	|	`Boolean`	|	-	|	If Y, then this report has its receipt receipt confirmed by the Expense Processor. Format: Y/N
 `SubmitDate`	|	`DateTime`	|	-	|	The date the report was submitted.


### PR DESCRIPTION
adding this Pull Request on behalf of Scott Meier in Support.  (I also created a wiki on how to do Pull Requests for his team).  Here is his email that explains the change to the data element that was originally (and incorrectly) listed as PolicyID instead of what works which is PolKey....

From: "Meier, Scott" Scott.Meier@concur.com
Date: Wednesday, May 11, 2016 at 2:43 PM
To: "Snyder, Nathan" Nathan.Snyder@concur.com, "Ahlstedt, Zachary" Zachary.Ahlstedt@concur.com, "Adinarayanan, Viswanathan" Viswanathan.Adinarayanan@concur.com, "Staab, Douglas" DouglasS@concur.com, "Ravikumar, Mukund" Mukund.Ravikumar@concur.com, Jessica Staley JessicaS@concur.com
Subject: API Documentation Update - PolicyID

Hi Team,

I noticed an issue while working on a Partner case recently.

We were trying to create an expense report based on the policyID using:

POST  https://www.concursolutions.com:443/api/v3.0/expense/reports

Post Body:
<Report>
<UserDefinedDate>2016-03-25</UserDefinedDate>
<Name>Expense Report via EmailXpenC</Name>
<Purpose>Expense Report created via EmailXpenC</Purpose>
<PolicyID>gWpoGayEkgmPRJBXcVXsCHpXpNqazf7n2Aw</PolicyID>
</Report>

This was resulting with <Error><Message>Unexpected error. Please contact Developer Support</Message><Server-Time>2016-03-01T05:49:32</Server-Time><Id>93E03D75-948B-486A-BEFD-848CA3DAC2A6</Id></Error>

With the assistance of Nathan, we realized that the <PolicyID> parameter is incorrectly stated. It should instead read: <PolKey></PolKey>. Once I changed the PolicyID to PolKey, it worked successfully and the error was gone.

In the documentation here: https://developer.concur.com/api-reference/expense/expense-report/reports.html - it states PolicyID  as the element name, which should read PolKey instead.

Thank you!

Scott Meier
Client Support Analyst I
Concur Technologies
