### PR TITLE
Update connection-requests-resource.markdown

### DIFF
--- a/api-reference/common/connection-requests/connection-requests-resource.markdown
+++ b/api-reference/common/connection-requests/connection-requests-resource.markdown
@@ -7,19 +7,23 @@ layout: reference
 
 The Connection Requests resource is used to integrate TripLink partner applications with Concur. It can be used to create, update, and manage connections between a user's Concur account and a select travel loyalty program. With Connection Requests a TripLink partner application can retrieve new connection requests and provide status for pending connections, successful connections, and failed connections. When retrieving new connections, the results can be filtered by status, page offset, and a limit for the number of records to return.
 
+In version 3.1, connection requests can also associate users to loyalty programs with e-mail addresses, in addition to utilizing loyalty numbers.
+
 * [Retrieve all connection requests that match the TripLink supplier ID](#get)
 * [Retrieve a connection request by ID](#getID)
 * [Create a connection request on behalf of a specific user](#post)
 * [Update a connection request](#put)
-* [Schema](#schema)
+* [Schema 3.0](#schema)
+* [Schema 3.1](#schema31)
 
 
 ### Version
-3.0
+3.0, 3.1
 
 ## <a name="get"></a>Retrieve all connection requests tht match the TripLink supplier ID
 
     GET  /api/v3.0/common/connectionrequests/
+    GET  /api/v3.1/common/connectionrequests/
 
         
 ### Parameters
@@ -35,6 +39,7 @@ Name | Type | Format | Description
 ## <a name="getID"></a>Retrieve a connection request by ID
 
     GET  /api/v3.0/common/connectionrequests/{id}
+    GET  /api/v3.1/common/connectionrequests/{id}
 
 
 ### Parameters
@@ -42,12 +47,12 @@ Name | Type | Format | Description
 Name | Type | Format | Description
 -----|------|--------|------------
 `id`	|	``path``	|	``string``	|	**Required** The connection request ID.
-`content`	|	``body``	|	-	|	**Required** The connection request object to update.
 
 
 ## <a name="post"></a>Create a connection request on behalf of a specific user
 
     POST  /api/v3.0/common/connectionrequests/
+    POST  /api/v3.1/common/connectionrequests/
 
 
 ### Parameters
@@ -60,6 +65,7 @@ Name | Type | Format | Description
 ## <a name="put"></a>Update a connection request
 
     PUT  /api/v3.0/common/connectionrequests/{id}
+    PUT  /api/v3.1/common/connectionrequests/{id}
 
 
 ### Parameters
@@ -69,7 +75,7 @@ Name | Type | Format | Description
 `id`	|	``path``	|	``string``	|	**Required** The connection request ID.
 `content`	|	``body``	|	-	|	**Required** The connection request object to update.
 
-## <a name="schema"></a>Schema
+## <a name="schema"></a>Schema 3.0
 
 
 ### <a name="connectionrequets"></a>Connection Requests
@@ -93,5 +99,42 @@ Name | Type | Format | Description
 `RequestToken`	|	``string``	|	-	|	The request token.
 `Status`	|	``string``	|	-	|	The status code representing the state of the connection request.
 `URI`	|	``string``	|	-	|	The URI to the resource.
+
+## <a name="schema31"></a>Schema 3.1
+
+
+### <a name="connectionrequets31"></a>Connection Requests
+
+Name | Type | Format | Description
+-----|------|--------|------------
+`Items`	|	``array``	|	[Connection Request](#connectionrequest31)	|	The result collection.
+`NextPage`	|	``string``	|		|	The URI of the next page of results, if any.
+
+
+### <a name="connectionrequest31"></a>Connection Request
+
+Name | Type | Format | Description
+-----|------|--------|------------
+`FirstName`	|	``string``	|	-	|	The user's first name.
+`ID`	|	``string``	|	-	|	The unique identifier of the resource.
+`LastModified`	|	``string``	|	-	|	The date and time when the connection request was last modified. Format: UTC
+`LastName`	|	``string``	|	-	|	The user's last name.
+`LoyaltyNumber`	|	``string``	|	-	|	The user's travel loyalty number.
+`MiddleName`	|	``string``	|	-	|	The user's middle name.
+`RequestToken`	|	``string``	|	-	|	The request token.
+`Status`	|	``string``	|	-	|	The status code representing the state of the connection request.
+`URI`	|	``string``	|	-	|	The URI to the resource.
+`EmailAddresses`	|	``UserEmailAddresses``	|	[User Email Addresses](#useremailaddresses)	|	Email addresses associated with the user.
+
+
+### <a name="useremailaddresses"></a>User Email Addresses
+
+Name | Type | Format | Description
+-----|------|--------|------------
+`Email1`	|	``string``	|	-	|	The user's email address.
+`Email2`	|	``string``	|	-	|	The user's email address.
+`Email3`	|	``string``	|	-	|	The user's email address.
+`Email4`	|	``string``	|	-	|	The user's email address.
+`Email5`	|	``string``	|	-	|	The user's email address.
 
 


### PR DESCRIPTION
Add new schema information for version 3.1, and correct the documentation for the GET by id.

This can go into production after the June 2016 release (SU128).