### PR TITLE
Change from 'Authentication' to 'Authorization'

### DIFF
--- a/api-alpha/receipts/migrationguide.markdown
+++ b/api-alpha/receipts/migrationguide.markdown
@@ -7,7 +7,7 @@ layout: reference
 
 ###  What is new and different?
 
-- If you are migrating from version 3 to version 4, you will need to use a new [Authentication API](https://preview.developer.concur.com/api-alpha/auth/apidoc.html).
+- If you are migrating from version 3 to version 4, you will need to use a new [Authorization API](https://preview.developer.concur.com/api-alpha/auth/apidoc.html).
 
 - In version 4, there are no matching facts. Clients post receipts for specific users.
 


### PR DESCRIPTION
Callers of APIs almost never authenticate directly  -- I can't think of a scenario EXCEPT for internal service usage, and for that the authentication is X.509 certificates, not an authentication API. External callers always get authorization to use an API on behalf of another, and there may be authentication involved in that process.