### PR TITLE
change auth header scheme based on token format

### DIFF
--- a/_includes/swagger.html
+++ b/_includes/swagger.html
@@ -30,13 +30,15 @@
 
 <script type="text/javascript">
   var swaggerUI = undefined;
+  var oauthTokenPattern = /^\d_.*$/g;
 
   function addApiKeyAuthorization(){
     // var key = encodeURIComponent($('#input_apiKey')[0].value);
     var key = $('#input_apiKey')[0].value;
     if(key && key.trim() != "") {
-
-      var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization", "OAuth " + key, "header");
+      var authScheme = oauthTokenPattern.test(key) ? "OAuth" : "Bearer";
+      var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization", authScheme + " " + key, "header");
+      
       swaggerUI.api.clientAuthorizations.add("api_key", apiKeyAuth);
 
       log("added key " + key);


### PR DESCRIPTION
looks at the token to determine the scheme for the authorization header
* if the token starts with a number and underscore (e.g. '1_...'), set scheme to `OAuth`
* otherwise, set scheme to `Bearer`