### PR TITLE
Remove Display column from preference levels table

### DIFF
--- a/tools-support/reference/hotel-direct-connect-codes.markdown
+++ b/tools-support/reference/hotel-direct-connect-codes.markdown
@@ -449,11 +449,11 @@ PendingCancellation |
 
 ## <a name="method8"></a>Preference Levels
 
-Value | Text Value | Display
------|----- | -----
-1 |company_less_preferred | ---
-2 |company_preferred Two silver |diamonds
-3 |company_most_preferred |Three silver diamonds
-4 |less_preferred |One golden diamond
-5 |preferred |Two golden diamonds
+Value | Text Value
+-----|-----
+1 |company_less_preferred
+2 |company_preferred Two silver
+3 |company_most_preferred
+4 |less_preferred
+5 |preferred
 10| most_preferred |Three golden diamonds 


### PR DESCRIPTION
The Display information for preference levels was out of date--diamonds are no longer used.  This removes the column entirely.