### PR TITLE
Removing "configuring sandboxes" section

### DIFF
--- a/tools-support/support.markdown
+++ b/tools-support/support.markdown
@@ -9,11 +9,6 @@ redirect_from: /docs-and-resources/support/
 
 - - -
 
-#### Configuring Sandboxes:
-You can get assistance for your developer sandbox configuration by going to the [Concur Forums for Sandbox Setup][1] page.
-
-- - -
-
 #### Recovering Passwords:
 To recover your developer sandbox user name or password, click on the applicable links: [Username][4] or [Password][5]
 


### PR DESCRIPTION
Per feedback from Doug Staab, removing the guidance to partners to go to the forum for sandbox assistance.  Doug is wanting to de-emphasize sandbox creation on the dev center documentation, since the current standard sandboxes don't meet partner needs.