### PR TITLE
Change to hide sandboxes

### DIFF
--- a/manage-apps/register.html
+++ b/manage-apps/register.html
@@ -5,15 +5,14 @@ redirect_from: /register/
 ---
 
 <div class="col-md-12">
-  <h2>Sandbox Registration Information</h2>
+  <h2>Setting up a sandbox</h2>
   <p>
-    Sandbox registration is for Concur Platform Partners or Concur customer developers only. If you have a signed partner agreement with Concur,
-    or have contracted to develop applications for a specific Concur client, please reach out to your technical contact at Concur for assistance in
-    getting your sandbox. If you aren't sure who your technical contact at Concur is, you can reach out using our <a href="https://forum.developer.concur.com/">forum</a>
-    and someone will identify the right resource for you.
+    Sandboxes are required for partners or customers looking to use Concur's APIs to read and write data from Concur.  It is important that 
+    you contact your assigned technical resource at Concur for assistance in setting up a sandbox that best fits your scenario. 
+    If you are unsure of your technical contact, you can reach out on the Concur Developer Forum and someone will be able to help identify 
+    the right resource for you: <a href="https://forum.developer.concur.com/">forum</a>  Please indicate in your forum Post whether you are
+    looking to create an applications for all Concur clients to potentially use, are developing for a specific client, or if you are a 
+    TMC/reseller.
   </p>
-  <p>
-    If you don't have a signed Partner agreement and you would like to become a certified Concur Platform Partner, please send a request to this alias
-    (fees apply to become a certified partner): <a href="mailto:bizdev@concur.com">bizdev@concur.com</a>. We are looking for well-established businesses who are
-    committed to develop, market and support their integration.</p>
+  
 </div>


### PR DESCRIPTION
Wording may change in the future, but we needed to get the sandbox link hidden, as sandboxes created on dev center are causing issues for Partner Enablement and other teams