### PR TITLE
Create 2017-03-08-tls1-no-longer-supported.markdown

### DIFF
--- a/changelog/_posts/2017-03-08-tls1-no-longer-supported.markdown
+++ b/changelog/_posts/2017-03-08-tls1-no-longer-supported.markdown
@@ -1,0 +1,10 @@
+---
+layout: post
+title: Applications Using TLS 1.0 Will No Longer Work after March 31, 2017
+date: 2017-03-08
+---
+
+
+#### Applications Using TLS 1.0 Will No Longer Work after March 31, 2017
+
+Applications running on TLS 1.0 will no longer be able to connect to concursolutions.com starting March 31, 2017.  Please verify that encrypted traffic being sent to Concur is not using TLS 1.0 in order to avoid service outages.


### PR DESCRIPTION
Notifying developers that concursolutions.com will not allow TLS 1.0 connections after March 31st 2017