### PR TITLE
Added caching for app listing

### DIFF
--- a/app-management/actions/appListing.js
+++ b/app-management/actions/appListing.js
@@ -6,6 +6,7 @@ import { sharedHelpers } from '../utils/actionHelpers';
 export const APP_LISTING_REQUEST = 'APP_LISTING_REQUEST';
 export const APP_LISTING_FAILURE = 'APP_LISTING_FAILURE';
 export const APP_LISTING_SUCCESS = 'APP_LISTING_SUCCESS';
+export const APP_LISTING_INVALIDATE_CACHE = 'APP_LISTING_INVALIDATE_CACHE';
 
 export function appListingRequest() {
   return { type: APP_LISTING_REQUEST };
@@ -25,11 +26,21 @@ export function appListingSuccess(apps) {
   };
 }
 
+export function appListingInvalidateCache() {
+  return { type: APP_LISTING_INVALIDATE_CACHE };
+}
+
 export function fetchAppListing() {
   return (dispatch, getState) => {
     dispatch(appListingRequest());
 
-    const { token } = getState().auth;
+    const {
+      appListing: { validCache },
+      auth: { token },
+    } = getState();
+
+    if (validCache) return null;
+
     const options = {
       method: 'GET',
       headers: {

--- a/app-management/reducers/appListing.js
+++ b/app-management/reducers/appListing.js
@@ -1,17 +1,21 @@
 import {
-  APP_LISTING_REQUEST,
-  APP_LISTING_FAILURE, APP_LISTING_SUCCESS,
+  APP_LISTING_REQUEST, APP_LISTING_FAILURE, APP_LISTING_SUCCESS,
+  APP_LISTING_INVALIDATE_CACHE,
 } from '../actions/appListing';
+import { AUTH_LOGOUT } from '../actions/auth';
+import { NEW_APP_SUCCESS } from '../actions/newApp';
 
 const defaultState = {
   apps: [],
   isFetching: false,
   error: '',
+  validCache: false,
 };
 
 function appListingReducer(state = defaultState, action) {
   switch (action.type) {
     case APP_LISTING_REQUEST:
+      if (state.validCache) return state;
       return {
         ...defaultState,
         isFetching: true,
@@ -25,6 +29,14 @@ function appListingReducer(state = defaultState, action) {
       return {
         ...defaultState,
         apps: action.apps,
+        validCache: true,
+      };
+    case APP_LISTING_INVALIDATE_CACHE:
+    case AUTH_LOGOUT:
+    case NEW_APP_SUCCESS:
+      return {
+        ...state,
+        validCache: false,
       };
     default:
       return state;

--- a/app-management/tests/actions/appListing.test.js
+++ b/app-management/tests/actions/appListing.test.js
@@ -17,11 +17,25 @@ describe('fetchAppListing', () => {
   beforeEach(() => {
     store = mockStore({
       auth: { token: 'a-sample-token' },
+      appListing: { validCache: false },
     });
   });
 
   afterEach(() => {
     nock.cleanAll();
+  });
+
+  it('does not create an appListingSuccess action when there is a valid cache', () => {
+    const expectedActions = [
+      appListingRequest(),
+    ];
+
+    store = mockStore({
+      auth: { token: 'a-sample-token' },
+      appListing: { validCache: true },
+    });
+
+    expect(store.dispatch(fetchAppListing())).toBeNull();
   });
 
   it('creates an appListingSuccess action when fetching is successful', () => {

--- a/app-management/tests/reducers/appListing.test.js
+++ b/app-management/tests/reducers/appListing.test.js
@@ -12,6 +12,7 @@ describe('appListing reducer', () => {
       apps: [],
       isFetching: false,
       error: '',
+      validCache: false,
     });
   });
 
@@ -23,6 +24,7 @@ describe('appListing reducer', () => {
       apps: [],
       isFetching: true,
       error: '',
+      validCache: false,
     });
   });
 
@@ -35,6 +37,7 @@ describe('appListing reducer', () => {
       apps: [],
       isFetching: false,
       error: message,
+      validCache: false,
     });
   });
 
@@ -50,6 +53,7 @@ describe('appListing reducer', () => {
       apps: apps,
       isFetching: false,
       error: '',
+      validCache: true,
     });
   });
 });


### PR DESCRIPTION
Added caching for app listing via a cache flag. Invalidation occurs on the `APP_LISTING_INVALIDATE_CACHE` action.

Additionally, the app listing reducer "listens" to other actions that should invalidate the cache, such as `AUTH_LOGOUT` and `NEW_APP_SUCCESS`