### PR TITLE
Added bug bounty message

### DIFF
--- a/vagrant/nginx/bug_bounty.txt
+++ b/vagrant/nginx/bug_bounty.txt
@@ -1,0 +1,3 @@
+Hello security researchers. The private key in this directory is for running the
+Concur Developer Center locally. This poses no security risk and will not be
+accepted for bounty.


### PR DESCRIPTION
Created a text file to alert researchers that the private key in `/vagrant/nginx` does not pose a security risk.