### PR TITLE
Update expense-report-get.markdown

### DIFF
--- a/api-reference-deprecated/version-two/expense-reports/expense-report-get.markdown
+++ b/api-reference-deprecated/version-two/expense-reports/expense-report-get.markdown
@@ -1,5 +1,5 @@
 ---
-title: Get report details
+title: Get report details.
 layout: reference
 ---
 


### PR DESCRIPTION
This API is not officially deprecated and it cannot be until v4 is released.  note: the v3 Entries API should not be used due to a major issue with the response related to reports being created by a Delegate - the report content does not come back in the response.  So, when we refer devs to this page, they instantly ask about the deprecation reference.  Can this be moved to a page where it doesn't state "deprecated" ?