### PR TITLE
Update revoke token doc

### DIFF
--- a/api-reference/authentication/apidoc.markdown
+++ b/api-reference/authentication/apidoc.markdown
@@ -196,10 +196,10 @@ Connection: Close
 
 ## <a name="revoke_token"></a>Revoking a token
 
-All refresh_tokens associated to a user for an application can be revoked by calling the `https://us-api.concursolutions.com/appmgmt/v0/connections` endpoint with a `DELETE` action. You have to provide the User's `accessToken` in the Authorization Header as `Authorization: Bearer <access_token>`.
+All refresh_tokens associated to a user for an application can be revoked by calling the `https://us.api.concursolutions.com/appmgmt/v0/connections` endpoint with a `DELETE` action. You have to provide the User's `accessToken` in the Authorization Header as `Authorization: Bearer <access_token>`.
 
 ```
-DELETE https://us-api.concursolutions.com/appmgmt/v0/connections
+DELETE https://us.api.concursolutions.com/appmgmt/v0/connections
 ```
 
 
@@ -215,7 +215,7 @@ Authorization: Bearer <access_token>
 
 ```http
 
-curl -X DELETE -H "Authorization: Bearer <accessToken>" "https://us-api.concursolutions.com/appmgmt/v0/connections"
+curl -X DELETE -H "Authorization: Bearer <accessToken>" "https://us.api.concursolutions.com/appmgmt/v0/connections"
 ```
 
 **Response**

--- a/api-reference/authentication/apidoc.markdown
+++ b/api-reference/authentication/apidoc.markdown
@@ -196,12 +196,10 @@ Connection: Close
 
 ## <a name="revoke_token"></a>Revoking a token
 
-All refresh_tokens associated to a user for an application can be revoked by calling the `https://api.concursolutions.com/appmgmt/v0/connections` endpoint with a `DELETE` action. You have to provide the User's `accessToken` in the Authorization Header as `Authorization: Bearer <access_token>`.
-
-**Note** The base URL for this endpoint is `https://api.concursolutions.com` instead of the normal `https://us.api.concursolutions.com`.
+All refresh_tokens associated to a user for an application can be revoked by calling the `https://us-api.concursolutions.com/appmgmt/v0/connections` endpoint with a `DELETE` action. You have to provide the User's `accessToken` in the Authorization Header as `Authorization: Bearer <access_token>`.
 
 ```
-DELETE https://api.concursolutions.com/appmgmt/v0/connections
+DELETE https://us-api.concursolutions.com/appmgmt/v0/connections
 ```
 
 
@@ -217,7 +215,7 @@ Authorization: Bearer <access_token>
 
 ```http
 
-curl -X DELETE -H "Authorization: Bearer <accessToken>" "https://api.concursolutions.com/appmgmt/v0/connections"
+curl -X DELETE -H "Authorization: Bearer <accessToken>" "https://us-api.concursolutions.com/appmgmt/v0/connections"
 ```
 
 **Response**


### PR DESCRIPTION
The revoke token endpoint changed fromhttps://api.concursolutions.com/appmgmt/v0/connections to https://us-api.concursolutions.com/appmgmt/v0/connections but the documentation wasn't updated to reflect this.