### PR TITLE
Advantage Memberships deprecated field notes

### DIFF
--- a/api-reference/travel-profile/01-profile-resource.markdown
+++ b/api-reference/travel-profile/01-profile-resource.markdown
@@ -613,7 +613,9 @@ A list of advantage memberships associated to a user:
 | `OptionCode` |  `string` |  The option code. Format: Varchar(20) | | | |
 | `ProgramName` | `string` | The program name. Format: Varchar(20) | Cannot Update | | |
 
-* **NOTE**:  Multiple memberships for the same VendorType, VendorCode, ProgramCode, and CardNumber are identified and a warning is thrown.
+* **NOTES**:
+ * Multiple memberships for the same VendorType, VendorCode, ProgramCode, and CardNumber are identified and a warning is thrown.
+ * OriginStationCode and DestinationStationCode fields are deprecated and should no longer be used. Use OriginCode and DestinationCode instead.
 
 ***
 


### PR DESCRIPTION
Updated the Advantage Memberships note section of the Travel Profile to specify that OriginStationCode and DestinationStationCode fields were deprecated.