### PR TITLE
Replaced broken link w/correct API Explorer link

### DIFF
--- a/api-guides/e-receipts.markdown
+++ b/api-guides/e-receipts.markdown
@@ -129,7 +129,7 @@ Refer to the sample Receipt POST body below for guidance:
 }
 ```
 
-Test your API in the [API Explorer](https://concurapi.readme.io/docs/post-e-receipt).  
+Test your API in the [API Explorer](/api-explorer/v3-0/Receipts.md).  
 
 
 #### If the user connection is initiated from the Partner site, it should follow Web Flow:


### PR DESCRIPTION
@elhansen748 Could you verify this change? The old readme.io link no longer exists.