### PR TITLE
Handles Breaking Change Intruduced by Webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,10 @@
 const webpack = require('webpack');
+const path = require('path');
 
 module.exports = {
   entry: ['./app-management/entry.jsx'],
   output: {
-    path: './assets/js',
+    path: path.resolve(__dirname, './assets/js'),
     filename: 'bundle.js'
   },
   resolve: {


### PR DESCRIPTION
- Webpack made a breaking change between 2.2.1 and 2.3.0 that requires
  the output path to be absolute
- See https://github.com/webpack/webpack/issues/4549 for more info
- Fixes #1094 