### PR TITLE
user_read is not a correct scope

### DIFF
--- a/api-reference/authentication/scopes.markdown
+++ b/api-reference/authentication/scopes.markdown
@@ -44,7 +44,7 @@ These are the list of scopes for the existing CONNECT APIs (v1.0 - v3.1)
 
 | Scope     | Description |
 |-----------|-------------|
-| user_read | Read user profile for old USER APIs |
+| user.read | Read user profile for old USER APIs |
 | ATTEND | Attendee List - Add, Update, or Inactivate Attendees |
 | CONFIG | Expense Configuration - Update Expense Feature Configuration |
 | CONREQ | Connection Request - Get or update connection requests to travel reward programs |


### PR DESCRIPTION
user_read was accidentally released, it should be user.read.  While user_read would still work, we don't want new apps being setup to use it, they should use user.read instead