### PR TITLE
Clarifying the user of Geolocations in advance of the China DC roll out

### DIFF
--- a/api-reference/authentication/apidoc.markdown
+++ b/api-reference/authentication/apidoc.markdown
@@ -15,7 +15,7 @@ If you are an existing partner with an existing app, please read both the [Migra
   * [Refreshing a token](#refresh_token)
   * [Revoking a token](#revoke_token)
   * [Token Management](#manage_token)
-  * [Base URIs](#base_uri)
+  * [Base URIs & Geolocation](#base_uri)
   * [ID Token](#id_token)
 * Types of grants
   * [Authorization grant](#auth_grant)
@@ -41,7 +41,7 @@ Name | Type | Format | Description
 `token_type`|`string`|-| The type of token returned. Value will be `Bearer`
 `access_token`|`string`|-|Token used to access pprotected resources of Concur's services.
 `refresh_token`|`string`|-|Refresh token required to request a new access token for a given user.
-`geolocation`|`string`|-|The base URL for where the user profile lives
+`geolocation`|`string`|-|The base URL for where the user profile lives. See (#base_uri) for usage.
 `id_token`|`string`|-|The OCID Token in the JSON Web Token (JWT) format that describes the user or company
 
 **Token Response**
@@ -201,7 +201,10 @@ e013335d-b4ce-4c43-a7e4-b67abc1adcb0
 
 It is highly recommended that you store Refresh Tokens together with your user's authorization metadata in your application every time you obtain a new `refreshToken` as they might change depending on different scenarios.
 
-## <a name="base_uri"></a>Base URIs
+## <a name="
+_uri"></a>Base URIs
+
+When making API calls, the appropriate base URI for the user's geolocation should be used. The following are the available base URIs:
 
 Environment | URI
 -----|------

--- a/api-reference/authentication/apidoc.markdown
+++ b/api-reference/authentication/apidoc.markdown
@@ -201,8 +201,7 @@ e013335d-b4ce-4c43-a7e4-b67abc1adcb0
 
 It is highly recommended that you store Refresh Tokens together with your user's authorization metadata in your application every time you obtain a new `refreshToken` as they might change depending on different scenarios.
 
-## <a name="
-_uri"></a>Base URIs
+## <a name="base_uri"></a>Base URIs
 
 When making API calls, the appropriate base URI for the user's geolocation should be used. The following are the available base URIs:
 

--- a/api-reference/authentication/getting-started.markdown
+++ b/api-reference/authentication/getting-started.markdown
@@ -33,6 +33,8 @@ curl -X POST -H 'concur-correlationid: nameofapp' "$oauth2_base/v0/token" --data
 
 Full docs: https://developer.concur.com/api-reference/authentication/apidoc.html#password_grant
 
+Store the token and geolocation.
+
 ## 3. Calling an API with the accessToken
 Once you have the `accessToken` in the form of a JWT (JSON Web Token), you need to supply this in an Authorization header in the form of `Authorization: Bearer <accessToken>` when making a HTTPS call. The `accessToken` is a large string that looks something like this:
 
@@ -40,7 +42,7 @@ Once you have the `accessToken` in the form of a JWT (JSON Web Token), you need 
 eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjE0NTU2MTQzNDYifQ.eyJhdWQiOiIqIiwic3ViIjoiaHR0cDovL21zcGNzcHJzcnFhLmNvbmN1ci5jb25jdXJ0ZWNoLm9yZzozMDAzL3Byb2ZpbGUtc2VydmljZS92MS91c2Vycy83NjAwOUFEMy1GNzdCLTREOTgtQTIxQS01NTNDOUM5MTc5RjAiLCJpc3MiOiJodHRwczovL2NvbmN1ci5jb20iLCJleHAiOjE0NzM4OTUxMjksImxlZ2FjeV9hcHBsaWNhdGlvbl9pZCI6MTUwMDA2MzY1OSwidXNlclVSSSI6Imh0dHA6Ly9tc3Bjc3Byc3JxYS5jb25jdXIuY29uY3VydGVjaC5vcmc6MzAwMy9wcm9maWxlLXNlcnZpY2UvdjEvdXNlcnMvNzYwMDlBRDMtRjc3Qi00RDk4LUEyMUEtNTUzQzlDOTE3OUYwIiwidXNlcnV1aWQiOiI3NjAwOUFEMy1GNzdCLTREOTgtQTIxQS01NTNDOUM5MTc5RjAiLCJuYmYiOjE0NzM4OTE1MjksImh0dHBzOi8vYXBpLmNvbmN1cnNvbHV0aW9ucy5jb20vYXBwIjoiaHR0cHM6Ly9hcGkuY29uY3Vyc29sdXRpb25zLmNvbS9hcHAtbWdtdC92MC9hcHBzL2UwMTBlMjVkLWI0Y2UtNGNlMy1hN2U0LWI2NzBjYjFhZGNiMCIsImh0dHBzOi8vYXBpLmNvbmN1cnNvbHV0aW9ucy5jb20vc2NvcGVzIjpbIkNDQVJEIiwiQ09NUEQiLCJVU0VSIiwidXNlcl9yZWFkIiwiRU1FUkciLCJKT0JMT0ciLCJFUkVDUFQiLCJJVElORVIiLCJGSVNWQyIsIkxJU1QiLCJQQVNTViIsIkNPTkZJRyIsIkZPUCIsIkdIT1NUIiwiQ09OUkVRIiwiVFJJUElUIiwiQ09NUEFOWSIsInByb2ZpbGUiLCJFVlMiLCJlbWFpbCIsIlRSVlBUUyIsIkFUVEVORCIsIklOVlBPIiwiTk9USUYiLCJUUlZSRVEiLCJTVVBTVkMiLCJFWFBSUFQiLCJhZGRyZXNzIiwiRVhUUkNUIiwiUEFZQkFUIiwid3Jvbmdfc2NvcGUiLCJJTlZQTVQiLCJJTUFHRSIsIlRBWElOViIsIlJDVElNRyIsIlVOVVRYIiwiVFdTIiwiVE1DU1AiLCJCQU5LIiwiSU5WVkVOIiwib3BlbmlkIiwiTVRORyIsIklOU0dIVCIsIlRSVlBSRiIsIklOVlRWIiwiTUVESUMiLCJUU0FJIl0sImlhdCI6MTQ3Mzg5MTUyOX0.QHY4Mc5A3J981-HDv7KUdgS4tUI-qnmQAxwe9J6DHxuMmYSoGEYZ0dsnLnqc2lO2iVJK6Pg3EBZTArq8_vzV2FK7tA4-IT1eCEHo1e-RWZyWLnR7P56SvZozXpY73daovSH7572HrUm21FXcyLmdaLZyo2LfFcChaghbSCjm1Jg1duH-pLPUW4d89-_pdakmyxfV3GCm2N_XQXoRhNYAAiZcG8UfxEn3TpMHJ96F2n6keJanT_Sn2Sek_sH2EmeeCpg5-jDe0fvLvr1-gY5t0ifq8QBKWHSUUIrGbQvseD6CGzfyiFUqVypN2lukfWACR-26otN50c0OzY6kgY06RA
 ```
 
-Armed with the `accessToken` you can start making calls to Concur's API. Here's an example to retrieve profile information for a User in the Production environment using cURL ([Base URIs for other Environments](/api-reference/authentication/apidoc.html#base_uri)):
+Armed with the `accessToken` you can start making calls to Concur's API. Here's an example to retrieve profile information for a User in the Production environment using cURL (utilize the appropriate base URI per the user's geolocation. [Base URIs for other Environments](/api-reference/authentication/apidoc.html#base_uri)):
 
 ```shell
 curl -k -v -H "Accept: application/json" \


### PR DESCRIPTION
All API users should leverage the geolocation to ensure that they are utilizing the appropriate endpoints for their apps. Adjusted the docs for base URI to make that clear.