### PR TITLE
Fixing typo per user feedback

### DIFF
--- a/manage-apps/register.html
+++ b/manage-apps/register.html
@@ -16,7 +16,7 @@ redirect_from: /register/
      <ol>
        <li>Develop an application for the Concur App Center.  This requires a signed Partner Agreement.
        <li>Develop an application as a Concur client (or for a client).  The client must purchase the Web Services SKU.
-       <li>Devleop an application as a TMC/reseller.
+       <li>Develop an application as a TMC/reseller.
      </ol>
   </p>
   <p>


### PR DESCRIPTION
Develop was incorrectly spelled.