### PR TITLE
Fixing typo

### DIFF
--- a/manage-apps/register.html
+++ b/manage-apps/register.html
@@ -20,7 +20,7 @@ redirect_from: /register/
      </ol>
   </p>
   <p>
-    Please read thorugh this page for more information: <a href="/why-concur.html">Why Concur</a>
+    Please read through this page for more information: <a href="/why-concur.html">Why Concur</a>
   </p>
   
 </div>


### PR DESCRIPTION
Fixing typo, "thorough" should be "through".