### PR TITLE
Add cleaner deprecation notices to API guides and docs

### DIFF
--- a/_includes/deprecation-alert.html
+++ b/_includes/deprecation-alert.html
@@ -1,0 +1,15 @@
+<div class="alert alert-danger">
+  <p>
+    {% if include.unsupported_date %}
+      <strong>
+        The following APIs will be deprecated on {{ include.deprecation_date }} and unsupported on {{ include.unsupported_date }}:
+      </strong>
+    {% else %}
+    <strong>The following APIs will be deprecated on {{ include.deprecation_date }}:</strong>
+    {% endif %}
+  </p>
+
+  <p>{{ include.content | markdownify }}</p>
+
+  <small>This API will be deprecated as per our <a href="/tools-support/reference/deprecation-policy.html">API Lifecycle & Deprecation Policy.</a></small>
+</div>

--- a/_layouts/reference.html
+++ b/_layouts/reference.html
@@ -13,9 +13,9 @@ layout: default
       <div class="col-md-9 markdown-body">
 
         {% if page.reference-type == 'swagger' %}
-          <div class="pull-right">
+          <div class="form-group">
             <label for="input_apiKey">Access Token</label>
-            <input id="input_apiKey" type="text">
+            <input class="form-control" id="input_apiKey" type="text">
           </div>
         {% endif %}
 

--- a/api-explorer/v3-0/AttendeeTypes.markdown
+++ b/api-explorer/v3-0/AttendeeTypes.markdown
@@ -4,9 +4,12 @@ layout: reference
 reference-type: swagger
 ---
 
-**DEPRECATED: 05/19/2016 UNSUPPORTED: 11/19/2016**
+{% capture deprecation_content %}
+* POST `/expense/attendeetypes`
+* DELETE `/expense/attendeetypes/{id}`
+{% endcapture %}
 
-* POST
-* DELETE
+{% include deprecation-alert.html deprecation_date="05/19/2016" unsupported_date="11/19/2016" content=deprecation_content %}
+
 
 {% swagger /api-explorer/v3-0/AttendeeTypes.swagger2.json %}

--- a/api-explorer/v3-0/Attendees.markdown
+++ b/api-explorer/v3-0/Attendees.markdown
@@ -4,8 +4,10 @@ layout: reference
 reference-type: swagger
 ---
 
-**DEPRECATED: 05/19/2016 UNSUPPORTED: 11/19/2016**
+{% capture deprecation_content %}
+* DELETE `/expense/attendees/{id}`
+{% endcapture %}
 
-* DELETE
+{% include deprecation-alert.html deprecation_date="05/19/2016" unsupported_date="11/19/2016" content=deprecation_content %}
 
 {% swagger /api-explorer/v3-0/Attendees.swagger2.json %}

--- a/api-explorer/v3-0/Lists.markdown
+++ b/api-explorer/v3-0/Lists.markdown
@@ -4,8 +4,10 @@ layout: reference
 reference-type: swagger
 ---
 
-**DEPRECATED: 05/19/2016 UNSUPPORTED: 11/19/2016**
+{% capture deprecation_content %}
+* PUT `/common/lists/{id}`
+{% endcapture %}
 
-* PUT
+{% include deprecation-alert.html deprecation_date="05/19/2016" unsupported_date="11/19/2016" content=deprecation_content %}
 
 {% swagger /api-explorer/v3-0/Lists.swagger2.json %}

--- a/api-explorer/v3-0/Receipts.markdown
+++ b/api-explorer/v3-0/Receipts.markdown
@@ -4,6 +4,14 @@ layout: reference
 reference-type: swagger
 ---
 
+{% capture deprecation_content %}
+* POST `/common/receipts`
 
+<br>
+
+Going forward, please use the [v4 Receipts](/api-reference/receipts/get-started.html) for any new development and apps.
+{% endcapture %}
+
+{% include deprecation-alert.html deprecation_date="02/07/2017" unsupported_date="08/07/2017" content=deprecation_content %}
 
 {% swagger /api-explorer/v3-0/Receipts.swagger2.json %}

--- a/api-reference-deprecated/old-auth/old-auth.markdown
+++ b/api-reference-deprecated/old-auth/old-auth.markdown
@@ -5,11 +5,11 @@ layout: reference
 
 # Authentication
 
-**New Authentication documentation can be found [here](/api-reference/authentication/getting-started.html)**
+{% capture deprecation_content %}
+If you are a new partner or an existing one creating a new app, please refer to the [new authentication version documentation](/api-reference/authentication/getting-started.html). Please contact your Partner Enablement representative before starting any new development to ensure a smooth and successful certification process. In addition, if you are an existing partner with an existing app, you may want to start planning to migrate to the new authentication once notification of deprecation is posted [here](/changelog).
+{% endcapture %}
 
-**DEPRECATION PROCESS NOTICE:** This authentication version will be deprecated on February 4, 2017. If you are a new partner or an existing one creating a new app, please refer to the new authentication version documentation. Please contact your Partner Enablement representative before starting any new development to ensure a smooth and successful certification process. In addition, if you are an existing partner with an existing app, you may want to start planning to migrate to the new authentication once notification of deprecation is posted [here](/changelog/).
-
-The deprecation process for this API has begun on **Februrary 4, 2017**. Read our [deprecation policy](/tools-support/reference/deprecation-policy.html) to understand the details and to plan accordingly.
+{% include deprecation-alert.html deprecation_date="02/04/2017" content=deprecation_content %}
 
 
 * [Access tokens](#access-tokens)

--- a/api-reference-deprecated/version-three/receipts.markdown
+++ b/api-reference-deprecated/version-three/receipts.markdown
@@ -5,9 +5,17 @@ redirect_from: /api-reference/expense/receipts/
 ---
 
 
-# Receipts (DEPRECATED 02/07/2017)
+# Receipts
 
-Please use [4.0](/api-reference/receipts/get-started.html) for any new development and apps.
+{% capture deprecation_content %}
+* POST `/common/receipts`
+
+<br>
+
+Going forward, please use the [v4 Receipts](/api-reference/receipts/get-started.html) for any new development and apps.
+{% endcapture %}
+
+{% include deprecation-alert.html deprecation_date="02/07/2017" unsupported_date="08/07/2017" content=deprecation_content %}
 
 The Receipts resource represents receipts that can be posted to Concur by a provider company on behalf of opted-in users. This resource currently supports three types of receipts:
 
@@ -22,18 +30,19 @@ The Receipts resource represents receipts that can be posted to Concur by a prov
 * The Receipt Service only accepts receipts that are up to 6 months old. Older receipts will not be accepted.
 * Unlike all the other Concur API endpoints, the e-receipt requires the Concur Platform team to configure your sandbox to enable access. You can request assistance via our Concur [forums](https://forum.developer.concur.com/c/sandbox)
 
+### Operations
 
 * [Create a new receipt](#post)
 * [Schema](#schema)
 
 ### Version
-3.0 will be deprecated on February 7, 2016. Receipts version 3.0 will be officially deprecated as per our policy on Februrary 7, 2017. The API can still be used **by existing applications** after deprecation, but will no longer be supported six months after deprecation date, which would be August 7, 2017.  
+3.0 will be deprecated on February 7, 2017. Receipts version 3.0 will be officially deprecated as per our policy on Februrary 7, 2017. The API can still be used **by existing applications** after deprecation, but will no longer be supported six months after deprecation date, which would be August 7, 2017.  
 
 Please use [4.0](/api-reference/receipts/get-started.html) for any new development and apps.  
 
 ## <a name="post"></a>Create a new receipt
 
-    POST  /api/v3.0/common/receipts
+    POST /api/v3.0/common/receipts
 
 
 ### Parameters

--- a/api-reference/receipts/get-started.markdown
+++ b/api-reference/receipts/get-started.markdown
@@ -25,7 +25,7 @@ layout: reference
 ### Version
 
 - 4.0
-- [3.0](https://developer.concur.com/api-reference-deprecated/version-three/receipts.html) [Deprecation Notice](https://developer.concur.com/changelog/2016/11/07/receipts-version-three-deprecation.html).
+- [3.0](/api-reference-deprecated/version-three/receipts.html) [Deprecation Notice](/changelog/2016/11/07/receipts-version-three-deprecation.html).
 
 #### Overview of Version 4.0
 


### PR DESCRIPTION
* Added new API deprecation notice (documentation can be found here)
* Fixed typo with receipts deprecation notice.