### PR TITLE
Updated vendor.markdown

### DIFF
--- a/api-reference/invoice/vendor.markdown
+++ b/api-reference/invoice/vendor.markdown
@@ -301,6 +301,7 @@ Name | Type | Format | Description
 `VendorCode`|`string`|-|**Required** The vendor code of the request.
 
 ### <a name="vendorgroups"></a>Vendor Group Input/Response Schema
+
 Name | Type | Format | Description
 -----|------|--------|------------
 `Items`|`array`|[`VendorGroup`](#VendorGroup)|The result collection.
@@ -310,6 +311,7 @@ Name | Type | Format | Description
 `VendorGroup`|`array`|[`VendorGroup`](#VendorGroup)|**Required** Vendor Group List
 
 ### <a name="VendorGroup"></a>VendorGroup
+
 Name | Type | Format | Description
 -----|------|--------|------------
 `ID`|`string`|-|The unique identifier of the resource.


### PR DESCRIPTION
Added another line between Vendor Group area headers and the following tables because it appears to be breaking formatting in the Concur API Reference website.