### PR TITLE
Update apidoc.markdown

### DIFF
--- a/api-reference/authentication/apidoc.markdown
+++ b/api-reference/authentication/apidoc.markdown
@@ -611,7 +611,6 @@ Connection: keep-alive
   "code": <number>,
   "error": <error>,
   "error_description": <error_description>,
-  "concur-correlationid": <concur_correlation_id>
   "geolocation": <geolocation url where user lives>
 }
 ```

--- a/api-reference/authentication/apidoc.markdown
+++ b/api-reference/authentication/apidoc.markdown
@@ -315,7 +315,7 @@ With this grant, the user has two authentication options:
 
 With both options, once the user is successfully authenticated and the user authorizes your application, the user will be redirected to the redirect_URI specified in the initial /authorize call with a temporary token appended.
 
-`<redirect_uri>?cc=<token>`
+`<redirect_uri>?geolocation=<token_geolocation>&cc=<token>`
 
 *If the user is not successfully authenticated or does not authorize the scopes for your application, an error code and description will be appended to the redirect URI. Please refer to the [Response Codes](#response_codes) section for more information.*
 
@@ -611,6 +611,7 @@ Connection: keep-alive
   "code": <number>,
   "error": <error>,
   "error_description": <error_description>,
+  "concur-correlationid": <concur_correlation_id>
   "geolocation": <geolocation url where user lives>
 }
 ```


### PR DESCRIPTION
I marked up two changes above.  Plus, I had the following question:  I see 'Base URIs for Obtaining a Token' section was updated to include a change in the following terminology:  'Token's geolocation rather than 'user's geolocation' (for user apps) or 'company's geolocation' (for enterprise apps) which is great.  But, for consitency.... will this updated terminology be updated throughout all references of geolocation in the Dev Portal?

## Pull Request Checklist

**Complete and check all items that are applicable.**

- [x] Proofread documentation changes for spelling and grammatical errors
- [x] Used Markdown code blocks for all applicable examples using code
- [x] Used relative links when linking to other documentation on Developer Center
- [x] If creating new API reference pages, followed the guidelines stated [in the wiki](https://github.com/concur/developer.concur.com/wiki/Creating-API-Reference-pages)
- [x] If moving pages, added [page redirects](https://github.com/concur/developer.concur.com/wiki/Adding-Redirects) so users are redirected to the new page
