### PR TITLE
Legacy id changes

### DIFF
--- a/app-management/components/AppDetailsPage/AppEditForm.jsx
+++ b/app-management/components/AppDetailsPage/AppEditForm.jsx
@@ -32,11 +32,13 @@ const constraints = {
   appType: {
     presence: { message: 'is required' },
   },
+  LegacyId: {
+  },
   redirectUris: {
     validateUrlArray: {
       allowLocal: true,
     },
-    firstElementRequired: false,
+    firstElementRequired: true,
   },
   allowedGrants: {
     presence: { message: '- at least one is required.' },
@@ -79,6 +81,15 @@ const EditAppForm = ({ handleSubmit }) => (
             label="App Type"
             options={appTypes}
             simpleValue
+          />
+        </section>
+        <section className="col-md-8">
+          <Field
+            component={InputField}
+            type="text"
+            name="legacyId"
+            label="Legacy Id &#42;"
+            placeholder="Legacy Id"
           />
         </section>
         <section className="col-md-8">

--- a/app-management/components/AppDetailsPage/AppEditForm.jsx
+++ b/app-management/components/AppDetailsPage/AppEditForm.jsx
@@ -32,13 +32,12 @@ const constraints = {
   appType: {
     presence: { message: 'is required' },
   },
-  LegacyId: {
-  },
+
   redirectUris: {
     validateUrlArray: {
       allowLocal: true,
     },
-    firstElementRequired: true,
+    firstElementRequired: false,
   },
   allowedGrants: {
     presence: { message: '- at least one is required.' },
@@ -88,7 +87,7 @@ const EditAppForm = ({ handleSubmit }) => (
             component={InputField}
             type="text"
             name="legacyId"
-            label="Legacy Id &#42;"
+            label="Legacy Id"
             placeholder="Legacy Id"
           />
         </section>

--- a/app-management/components/NewAppPage/NewAppForm.jsx
+++ b/app-management/components/NewAppPage/NewAppForm.jsx
@@ -34,11 +34,13 @@ const constraints = {
   appType: {
     presence: { message: 'is required' },
   },
+  LegacyId: {
+  },
   redirectUris: {
     validateUrlArray: {
       allowLocal: true,
     },
-    firstElementRequired: false,
+    firstElementRequired: true,
   },
   allowedGrants: {
     presence: { message: '- at least one is required.' },
@@ -88,6 +90,15 @@ const NewAppForm = ({ handleSubmit }) => (
             name="appType"
             label="App Type &#42;"
             options={appTypes}
+          />
+        </section>
+        <section className="col-md-8">
+          <Field
+            component={InputField}
+            type="text"
+            name="legacyId"
+            label="Legacy Id &#42;"
+            placeholder="Legacy Id"
           />
         </section>
         <section className="col-md-8">

--- a/app-management/components/NewAppPage/NewAppForm.jsx
+++ b/app-management/components/NewAppPage/NewAppForm.jsx
@@ -34,13 +34,12 @@ const constraints = {
   appType: {
     presence: { message: 'is required' },
   },
-  LegacyId: {
-  },
+
   redirectUris: {
     validateUrlArray: {
       allowLocal: true,
     },
-    firstElementRequired: true,
+    firstElementRequired: false,
   },
   allowedGrants: {
     presence: { message: '- at least one is required.' },
@@ -97,7 +96,7 @@ const NewAppForm = ({ handleSubmit }) => (
             component={InputField}
             type="text"
             name="legacyId"
-            label="Legacy Id &#42;"
+            label="Legacy Id"
             placeholder="Legacy Id"
           />
         </section>


### PR DESCRIPTION
PR Against this issue url:
#1231

Requirements:

A legacyID field should be added to the app creation form.
The legacyID field should not be required.
No validation of the id should be done. Assumption is the user will know and enter the correct value. If they enter the wrong value they can edit the app and fix it.
When a user logs in to view all their apps, if a legacyID is returned it should be displayed to the user in the UI.
The user should be able to edit the legacyID of any app they own.

Activity: 
Review Comments Incorporated

Issue Status : Resolved

Old PR link: https://github.com/concur/developer.concur.com/pull/1267