### PR TITLE
Add legacyId to decomposeApp to display properly in UI

### DIFF
--- a/app-management/utils/actionHelpers.js
+++ b/app-management/utils/actionHelpers.js
@@ -89,6 +89,7 @@ export const sharedHelpers = {
       allowedGrants: allowedGrants.map(matchElementToLabel(grants)),
       allowedScopes: allowedScopes.map(matchElementToLabel(scopes)),
       appType: appType.map(matchElementToLabel(appTypes)),
+      legacyId: applicationData['com:concur:internal:product:Identifiers:1.0'].legacyId,
       ...applicationData,
     };
   },


### PR DESCRIPTION
Since the legacyId is nested within 'com:concur:internal:product:Identifiers:1.0', the UI doesn't display the legacyId because it's expecting it to be a root property of the app.

Working around this by mapping the value to `legacyId`