### PR TITLE
Add includeGuestBookings parameter to trips API

### DIFF
--- a/api-reference/travel/itinerary/trip/trip-resource.markdown
+++ b/api-reference/travel/itinerary/trip/trip-resource.markdown
@@ -53,6 +53,7 @@ To identify a specific user by login ID or XMLSyncID, you can specify the follow
 |ItemsPerPage|number|integer|The includeMetadata query parameter combined with the ItemsPerPage and Page query parameters will cause the response to be divided into pages. The response will be wrapped in a ConcurResponse parent element, with both the response details and the paging metadata included. If the ItemsPerPage query parameter is not sent, the response will default to 200 if the Page query parameter is sent, or 1000 if the Page query parameter is not set. If the Page query parameter is not sent, the response will default to page 1.|
 |includeVirtualTrip|flag|integer	|Virtual trips are segments booked offline through the Travel Request product. Set the includeVirtualTrip query parameter to 1 to include those trips in the list.|
 |includeCanceledTrips	|true/false|string|The includeCanceledTrips query parameter will cause the request to also return trips with a status of Canceled. When this query parameter is set to true, the response will include the TripStatus element.|
+|includeGuestBookings |true/false|string|The includeGuestBookings query parameter will casuse the request to show guest bookings if set to true.It is set to false by default.|
 
 Here are some examples of how to format GET requests using a combination of these query parameters:
 


### PR DESCRIPTION
This parameter is missing in the documentation even though it is an existing parameter that was added via this Jira ticket
https://jira.concur.com/jira/browse/CLQ-65287

## Pull Request Checklist

**Complete and check all items that are applicable.**

- [x] Proofread documentation changes for spelling and grammatical errors
- [x] Used Markdown code blocks for all applicable examples using code
- [x] Used relative links when linking to other documentation on Developer Center
- [x] If creating new API reference pages, followed the guidelines stated [in the wiki](https://github.com/concur/developer.concur.com/wiki/Creating-API-Reference-pages)
- [x] If moving pages, added [page redirects](https://github.com/concur/developer.concur.com/wiki/Adding-Redirects) so users are redirected to the new page
