### PR TITLE
Attempt to add 2018 to release notes section

### DIFF
--- a/tools-support/release-notes/index.markdown
+++ b/tools-support/release-notes/index.markdown
@@ -8,9 +8,9 @@ layout: reference
 
 | 2018 | 2017 | 2016 | 2015 | 2014 |
 | ----- | ----- | ----- | ----- | ----- |
-| -- | -- | -- | -- |
-| -- | [February](#feb2016) | [February][2-4] | -- |
-| [March](/changelog/2017/03/20/Digital-Tax-Invoice-API-Account-Id.html) | [March Release](/blog/2016/03/15/march-release-notes.html) - [Quick Expense](/blog/2016/03/18/quick-expense-api-payment-type.html) | -- | -- |
+| -- | -- | -- | -- | -- |
+| -- | -- | [February](#feb2016) | [February][2-4] | -- |
+| -- | [March](/changelog/2017/03/20/Digital-Tax-Invoice-API-Account-Id.html) | [March Release](/blog/2016/03/15/march-release-notes.html) - [Quick Expense](/blog/2016/03/18/quick-expense-api-payment-type.html) | -- | -- |
 | -- | [April](#april2016) | [April][2-5] | -- |
 | -- | -- | [May][2-6] | [May][2-1] |
 | -- | -- | -- | [June][2-2] |

--- a/tools-support/release-notes/index.markdown
+++ b/tools-support/release-notes/index.markdown
@@ -14,19 +14,19 @@ layout: reference
 | -- | -- | [April](#april2016) | [April][2-5] | -- |
 | -- | -- | -- | [May][2-6] | [May][2-1] |
 | -- | -- | -- | -- | [June][2-2] |
-| -- | -- | [July](#july2015) | -- |
-| -- | -- | [August](#august2015) | -- |
-| -- | -- | -- | -- |
-| -- | -- | -- | [October][2-3] |
-| -- | [November](/changelog/2016/11/19/connect-api-deprecation-notice.html) | -- | -- |
-| -- | -- | -- | -- |
+| -- | -- | -- | [July](#july2015) | -- |
+| -- | -- | -- | [August](#august2015) | -- |
+| -- | -- | -- | -- | -- |
+| -- | -- | -- | -- | [October][2-3] |
+| -- | -- | [November](/changelog/2016/11/19/connect-api-deprecation-notice.html) | -- | -- |
+| -- | -- | -- | -- | -- |
 
 # App Center Release Notes
 
 | 2018 | 2017 | 2016 | 2015 | 2014 |
 | ----- | ----- | ----- | ----- | ----- |
 | -- | [January](AppCenter_ReleaseNotes_Jan 2017_FINAL.pdf) | [January](AppCenter_ReleaseNotes_January_2016_FINAL.pdf) | -- | -- |
-| -- | [February](AppCenter_ReleaseNotes_Feb 2017_FINAL.pdf) | [February](AppCenter_ReleaseNotes_February 2016_DRAFT.pdf) | [February][1-10]
+| -- | [February](AppCenter_ReleaseNotes_Feb 2017_FINAL.pdf) | [February](AppCenter_ReleaseNotes_February 2016_DRAFT.pdf) | [February][1-10] | -- |
 | -- | -- | [March](AppCenter_ReleaseNotes_March 2016_FINAL.pdf) | [March][1-11] | -- |
 | -- | -- | -- | [April][1-12] | -- |
 | -- | [May](AppCenter_ReleaseNotes_May 2017_DRAFT.pdf)| [May](AppCenter_ReleaseNotes_May 2016_FINAL.pdf) | [May][1-13] | [May](App_Center_Release_Notes_client_final_May2014.pdf) |

--- a/tools-support/release-notes/index.markdown
+++ b/tools-support/release-notes/index.markdown
@@ -6,8 +6,8 @@ layout: reference
 
 # Developer Platform Release Notes
 
-| 2017 | 2016 | 2015 | 2014 |
-| ---- | ---- | ---- | ---- |
+| 2018 | 2017 | 2016 | 2015 | 2014 |
+| ----- | ----- | ----- | ----- | ----- |
 | -- | -- | -- | -- |
 | -- | [February](#feb2016) | [February][2-4] | -- |
 | [March](/changelog/2017/03/20/Digital-Tax-Invoice-API-Account-Id.html) | [March Release](/blog/2016/03/15/march-release-notes.html) - [Quick Expense](/blog/2016/03/18/quick-expense-api-payment-type.html) | -- | -- |
@@ -23,20 +23,20 @@ layout: reference
 
 # App Center Release Notes
 
-| 2017 | 2016 | 2015 | 2014 |
-| ---- | ---- | ---- | ---- |
-| [January](AppCenter_ReleaseNotes_Jan 2017_FINAL.pdf) | [January](AppCenter_ReleaseNotes_January_2016_FINAL.pdf) | -- | -- |
-| [February](AppCenter_ReleaseNotes_Feb 2017_FINAL.pdf) | [February](AppCenter_ReleaseNotes_February 2016_DRAFT.pdf) | [February][1-10]
-| -- | [March](AppCenter_ReleaseNotes_March 2016_FINAL.pdf) | [March][1-11] | -- |
-| -- | -- | [April][1-12] | -- |
-| [May](AppCenter_ReleaseNotes_May 2017_DRAFT.pdf)| [May](AppCenter_ReleaseNotes_May 2016_FINAL.pdf) | [May][1-13] | [May](App_Center_Release_Notes_client_final_May2014.pdf) |
-| -- | [June](AppCenter_ReleaseNotes_June 2016_FINAL.pdf) | -- | [June][1-2] |
-| [July](AppCenter_ReleaseNotes_July 2017_FINAL.pdf) | [July](AppCenter_ReleaseNotes_July 2016_FINAL.pdf) | [July](AppCenter_ReleaseNotes_July2015FINAL.pdf) | [July][1-3] |
-| [August](AppCenter_ReleaseNotes_August 2017_DRAFT.pdf) | [August](AppCenter_ReleaseNotes_August 2016_FINAL.pdf) | -- | [August][1-4] |
-| [September](AppCenter_ReleaseNotes_September 2017_DRAFT.docx) | [September](AppCenter_ReleaseNotes_Sept 2016_FINAL.pdf) | [September](AppCenter_ReleaseNotes_Sept2015FINAL.pdf) | [September][1-5] |
-| [October](AppCenter_ReleaseNotes_October 2017_DRAFT.pdf) | [October](AppCenter_ReleaseNotes_Oct 2016_FINAL.pdf) | [October](AppCenter_ReleaseNotes_Oct2015FINAL_10_16_15.pdf) | [October][1-6] |
-| -- | [November](AppCenter_ReleaseNotes_Nov 2016_FINAL.pdf) | -- | [November][1-7] |
-| [December](AppCenter_ReleaseNotes_December 2017_Final.pdf) | [December](AppCenter_ReleaseNotes_Dec 2016_FINAL.pdf) | [December](AppCenter_ReleaseNotes_December2015FINAL.pdf) | [December][1-8] |
+| 2018 | 2017 | 2016 | 2015 | 2014 |
+| ----- | ----- | ----- | ----- | ----- |
+| -- | [January](AppCenter_ReleaseNotes_Jan 2017_FINAL.pdf) | [January](AppCenter_ReleaseNotes_January_2016_FINAL.pdf) | -- | -- |
+| -- | [February](AppCenter_ReleaseNotes_Feb 2017_FINAL.pdf) | [February](AppCenter_ReleaseNotes_February 2016_DRAFT.pdf) | [February][1-10]
+| -- | -- | [March](AppCenter_ReleaseNotes_March 2016_FINAL.pdf) | [March][1-11] | -- |
+| -- | -- | -- | [April][1-12] | -- |
+| -- | [May](AppCenter_ReleaseNotes_May 2017_DRAFT.pdf)| [May](AppCenter_ReleaseNotes_May 2016_FINAL.pdf) | [May][1-13] | [May](App_Center_Release_Notes_client_final_May2014.pdf) |
+| -- | -- | [June](AppCenter_ReleaseNotes_June 2016_FINAL.pdf) | -- | [June][1-2] |
+| -- | [July](AppCenter_ReleaseNotes_July 2017_FINAL.pdf) | [July](AppCenter_ReleaseNotes_July 2016_FINAL.pdf) | [July](AppCenter_ReleaseNotes_July2015FINAL.pdf) | [July][1-3] |
+| -- | [August](AppCenter_ReleaseNotes_August 2017_DRAFT.pdf) | [August](AppCenter_ReleaseNotes_August 2016_FINAL.pdf) | -- | [August][1-4] |
+| -- | [September](AppCenter_ReleaseNotes_September 2017_DRAFT.docx) | [September](AppCenter_ReleaseNotes_Sept 2016_FINAL.pdf) | [September](AppCenter_ReleaseNotes_Sept2015FINAL.pdf) | [September][1-5] |
+| -- | [October](AppCenter_ReleaseNotes_October 2017_DRAFT.pdf) | [October](AppCenter_ReleaseNotes_Oct 2016_FINAL.pdf) | [October](AppCenter_ReleaseNotes_Oct2015FINAL_10_16_15.pdf) | [October][1-6] |
+| -- | -- | [November](AppCenter_ReleaseNotes_Nov 2016_FINAL.pdf) | -- | [November][1-7] |
+| -- | [December](AppCenter_ReleaseNotes_December 2017_Final.pdf) | [December](AppCenter_ReleaseNotes_Dec 2016_FINAL.pdf) | [December](AppCenter_ReleaseNotes_December2015FINAL.pdf) | [December][1-8] |
 
 
 # Combined App Center and Developer Platform Release Notes

--- a/tools-support/release-notes/index.markdown
+++ b/tools-support/release-notes/index.markdown
@@ -11,9 +11,9 @@ layout: reference
 | -- | -- | -- | -- | -- |
 | -- | -- | [February](#feb2016) | [February][2-4] | -- |
 | -- | [March](/changelog/2017/03/20/Digital-Tax-Invoice-API-Account-Id.html) | [March Release](/blog/2016/03/15/march-release-notes.html) - [Quick Expense](/blog/2016/03/18/quick-expense-api-payment-type.html) | -- | -- |
-| -- | [April](#april2016) | [April][2-5] | -- |
-| -- | -- | [May][2-6] | [May][2-1] |
-| -- | -- | -- | [June][2-2] |
+| -- | -- | [April](#april2016) | [April][2-5] | -- |
+| -- | -- | -- | [May][2-6] | [May][2-1] |
+| -- | -- | -- | -- | [June][2-2] |
 | -- | -- | [July](#july2015) | -- |
 | -- | -- | [August](#august2015) | -- |
 | -- | -- | -- | -- |


### PR DESCRIPTION
Just got the first set of release notes for 2018, and realized that we didn't have a column for that year yet.

## Pull Request Checklist

**Complete and check all items that are applicable.**

- [ ] Proofread documentation changes for spelling and grammatical errors
- [ ] Used Markdown code blocks for all applicable examples using code
- [ ] Used relative links when linking to other documentation on Developer Center
- [ ] If creating new API reference pages, followed the guidelines stated [in the wiki](https://github.com/concur/developer.concur.com/wiki/Creating-API-Reference-pages)
- [ ] If moving pages, added [page redirects](https://github.com/concur/developer.concur.com/wiki/Adding-Redirects) so users are redirected to the new page
