### PR TITLE
Removing PaymentMethodType filter for Company level accesses of Vendor APIs

### DIFF
--- a/api-explorer/v3-0/Vendors.swagger2.json
+++ b/api-explorer/v3-0/Vendors.swagger2.json
@@ -31,7 +31,7 @@
           "Resources"
         ],
         "summary": "Retrieves an existing vendor.",
-        "description": "Gets an existing vendor.",
+        "description": "Gets an existing vendor. Note: If authenticating with a Company JWT the API will return all vendors associated with a specific entity.",
         "parameters": [
           {
             "name": "limit",

--- a/api-reference/invoice/vendor.markdown
+++ b/api-reference/invoice/vendor.markdown
@@ -20,6 +20,7 @@ layout: reference
 ## <a name="get"></a>Retrieve an existing vendor 
 
     GET  /api/v3.0/invoice/vendors
+    Note: If authenticating with a Company JWT the API will return all vendors associated with a specific entity.
 
 ### Parameters  
 


### PR DESCRIPTION
Minor changes to documentation to reflect that calls to the Invoice Vendors V3 API with a Company JWT no longer filter by PaymentMethodType=PAYPVD.