### PR TITLE
Clarifying Get Vendor V3 api after recent modifications

### DIFF
--- a/src/api-explorer/v3-0/Vendors.swagger2.json
+++ b/src/api-explorer/v3-0/Vendors.swagger2.json
@@ -31,7 +31,7 @@
           "Resources"
         ],
         "summary": "Retrieves an existing vendor.",
-        "description": "Gets an existing vendor.",
+        "description": "Gets an existing vendor. Note: If authenticating with a Company JWT the API will return all vendors associated with a specific entity.",
         "parameters": [
           {
             "name": "limit",

--- a/src/api-explorer/v3-0/Vendors.swagger2.json
+++ b/src/api-explorer/v3-0/Vendors.swagger2.json
@@ -105,6 +105,13 @@
             "type": "string"
           },
           {
+            "name": "paymentMethodType",
+            "in": "query",
+            "description": "Payment Method Type to be searched. Valid values are ACH, CARD, CHECK, CLIENT, PAYPVD, VCHER, WIRE",
+            "required": false,
+            "type": "string"
+          },
+          {
             "name": "address1",
             "in": "query",
             "description": "Address 1 to be searched",

--- a/src/api-reference/invoice/vendor.markdown
+++ b/src/api-reference/invoice/vendor.markdown
@@ -35,6 +35,7 @@ Name | Type | Format | Description
 `vendorName`|`string`|`query`|Vendor Name to be searched
 `taxID`|`string`|`query`|Tax ID to be searched
 `buyerAccountNumber`|`string`|`query`|Buyer Account Number to be searched
+`paymentMethodType`|`string`|`query`|Payment Method Type - valid values are ACH, CARD, CHECK, CLIENT, PAYPVD, VCHER, WIRE
 `addressCode`|`string`|`query`|Address Code to be searched
 `address1`|`string`|`query`|Address 1 to be searched
 `address2`|`string`|`query`|Address 2 to be searched

--- a/src/api-reference/invoice/vendor.markdown
+++ b/src/api-reference/invoice/vendor.markdown
@@ -20,6 +20,7 @@ layout: reference
 ## <a name="get"></a>Retrieve an existing vendor 
 
     GET  /api/v3.0/invoice/vendors
+    Note: If authenticating with a Company JWT the API will return all vendors associated with a specific entity.
 
 ### Parameters  
 


### PR DESCRIPTION
The V3 Get Vendor endpoint now supports retrieval of all vendors when using a Company JWT. The documentation has been changed to reflect reality.