### PR TITLE
Update payment-request.markdown

### DIFF
--- a/src/api-reference/invoice/payment-request.markdown
+++ b/src/api-reference/invoice/payment-request.markdown
@@ -119,7 +119,7 @@ Name | Type | Format | Description
 -----|------|--------|------------
 `Allocations`	|	`Array[Allocation]`	|	-	|	The details of the Payment Request Allocation Core Identity Fields.
 `AmountWithoutVat`	|	`string`	|	-	|	The net amount of the line item (excluding VAT).
-`Custom01` through `Custom20`	|	`string`	|	-	|	The details from the Custom fields. These may not have data, depending on configuration.
+`Custom1` through `Custom20`	|	`string`	|	-	|	The details from the Custom fields. These may not have data, depending on configuration.
 `Description`	|	`string`	|	-	|	Brief overview of the good or service ordered.
 `ExpenseTypeCode`	|	`string`	|	-	|	A code which indicates the Expense Type for the Line Item.
 `ItemCode`	|	`string`	|	-	|	Represents the item code (the unique code a vendor assigns to a good or code a vendor assigns to a good or service to identify it).
@@ -139,9 +139,9 @@ Name | Type | Format | Description
 
 Name | Type | Format | Description
 -----|------|--------|------------
-`Custom01` through `Custom07`	|	`string`	|	-	|	The details from the Custom fields. These may not have data, depending on configuration.
-`Custom08`	|	`string`	|	-	|	A value that can be applied to a custom field 8 that is part of the allocation form.
-`Custom09`	|	`string`	|	-	|	A value that can be applied to a custom field 9 that is part of the allocation form.
+`Custom1` through `Custom7`	|	`string`	|	-	|	The details from the Custom fields. These may not have data, depending on configuration.
+`Custom8`	|	`string`	|	-	|	A value that can be applied to a custom field 8 that is part of the allocation form.
+`Custom9`	|	`string`	|	-	|	A value that can be applied to a custom field 9 that is part of the allocation form.
 `Custom10`	|	`string`	|	-	|	A value that can be applied to a custom field 10 that is part of the allocation form.
 `Custom11` through `Custom20`	|	`string`	|	-	|	The details from the Custom fields. These may not have data, depending on configuration.
 `Percentage`	|	`string`	|	-	|	**Required** The percentage of the Request Line Item that the individual allocation record. All Allocations associated to a given Line Item should add up to 100.


### PR DESCRIPTION
All Custom and OrgUnit vales don't start from "0" including LineItem and Allocation, but the definition on this page including "0".

If we GET a Payment Request, sample of response is the below. You can see "0" is not included all Custom items for LineItem and Allocation. 

GET https://www.concursolutions.com/api/v3.0/invoice/paymentrequest/68467137F9ED4DD9AA65

HTTP Status:OK
HTTP Status Code:200
HTTP Method:GET
Content Type:application/json; charset=utf-8
Content Length:4695

{
  "EmployeeName": "申請者 JINS",
  "CurrencyCode": "JPY",
  "InvoiceNumber": null,
  "DataSource": "MAN",
  "LedgerCode": "AX(JP)",
  "CountryCode": "JP",
  "Name": "KS_APIGET確認JP",
  "Description": null,
  "OB10TransactionId": null,
  "OB10BuyerId": null,
  "BuyerCostCenter": null,
  "CheckNumber": null,
  "PaymentTermsDays": "30",
  "PaymentMethod": "CLIENT",
  "PaymentAdjustmentNotes": null,
  "ReceiptConfirmationType": "NONE",
  "IsInvoiceConfirmed": "false",
  "NotesToVendor": null,
  "DiscountTerms": null,
  "ApprovalStatus": "R_NOTF",
  "SubmittedByDelegate": "false",
  "ApprovedByDelegate": "false",
  "IsAssigned": "true",
  "CreatedByUsername": "testuser01@jins.com",
  "AssignedByUsername": null,
  "PaymentRequestCreatedByTestUser": "true",
  "PaymentRequestDeletedBy": null,
  "IsPaymentRequestDeleted": "false",
  "IsTestTransaction": "true",
  "IsPaymentRequestDuplicate": "false",
  "UserCreationDate": "2018-02-08 00:31:40.0",
  "InvoiceDate": "2018-02-01 00:00:00.0",
  "PostingDate": null,
  "FirstSubmitDate": null,
  "LastSubmitDate": null,
  "PaymentDueDate": "2018-03-03 00:00:00.0",
  "WorkflowCompleteDate": null,
  "ExtractDate": null,
  "PaidDate": null,
  "FirstApprovalDate": null,
  "AssignedDate": null,
  "DeletedDate": null,
  "InvoiceReceivedDate": null,
  "PaymentStatus": "R_NOTP",
  "InvoiceAmount": "2000.00000000",
  "CalculatedAmount": "2160.00000000",
  "TotalApprovedAmount": "2000.00000000",
  "ShippingAmount": "0.00000000",
  "TaxAmount": "0.00000000",
  "LineItemTotalAmount": "2000.00000000",
  "PaidAmount": null,
  "DiscountPercentage": null,
  "LineItemVatAmount": "160.00000000",
  "DeliverySlipNumber": null,
  "PurchaseOrderNumber": null,
  "OrgUnit1": "1000",
  "OrgUnit2": "0500000000",
  "OrgUnit3": null,
  "OrgUnit4": null,
  "OrgUnit5": null,
  "OrgUnit6": null,
  "Custom1": "KOUZA",
  "Custom2": null,
  "Custom3": null,
  "Custom4": null,
  "Custom5": null,
  "Custom6": null,
  "Custom7": null,
  "Custom8": null,
  "Custom9": null,
  "Custom10": null,
  "Custom11": null,
  "Custom12": null,
  "Custom13": null,
  "Custom14": null,
  "Custom15": null,
  "Custom16": null,
  "Custom17": null,
  "Custom18": null,
  "Custom19": null,
  "Custom20": null,
  "Custom21": null,
  "Custom22": "1000",
  "Custom23": null,
  "Custom24": null,
  "AmountWithoutVat": "2000.00000000",
  "VatAmountOne": "0.00000000",
  "VatAmountTwo": "0.00000000",
  "VatAmountThree": "0.00000000",
  "VatAmountFour": "0.00000000",
  "VatRateOne": "0.00000000",
  "VatRateTwo": "0.00000000",
  "VatRateThree": "0.00000000",
  "VatRateFour": "0.00000000",
  "TaxCode": null,
  "ProvincialTaxId": null,
  "VendorTaxId": null,
  "ExternalPolicyId": "BB015C3A7701469C93B1",
  "TaxCode2": null,
  "TaxCode3": null,
  "TaxCode4": null,
  "VendorRemitAddress": {
    "Name": "(株)JECC（日本電子計算機㈱）",
    "DiscountTerms": null,
    "AddressCode": "0009-825-9044522",
    "VendorCode": "0010520037",
    "Address1": "X000随時払い",
    "Address2": null,
    "Address3": "東京都千代田区丸の内3-4-1新国際ビル",
    "City": null,
    "State": "東京都",
    "PostalCode": "1008341",
    "CountryCode": "JP"
  },
  "VendorShipFromAddress": null,
  "CompanyBillToAddress": null,
  "CompanyShipToAddress": {
    "Name": "JINS",
    "Address1": "JINS",
    "Address2": null,
    "Address3": null,
    "City": "Idabashi",
    "State": null,
    "PostalCode": "123-4567",
    "CountryCode": "JP"
  },
  "LineItems": {
    "LineItem": [
      {
        "LineItemId": "2DEA14D6486B0749A55E490A7DF6F919",
        "ExpenseTypeCode": "2062",
        "RequestLineItemNumber": "1",
        "Quantity": "1",
        "Description": "SETSUMEI",
        "AllocationStatus": "NONE",
        "ShipToPostalCode": null,
        "ShipFromPostalCode": null,
        "LineItemIsTestUser": null,
        "PurchaseOrderNumber": null,
        "MatchedPurchaseOrderLineItemId": null,
        "IsMatched": "false",
        "SupplierPartId": null,
        "UnitOfMeasure": null,
        "UnitPrice": "2000.00000000",
        "TotalPrice": "2000.00000000",
        "RequestedLineItemAmount": "2000.00000000",
        "ApprovedLineItemAmount": "2000.00000000",
        "Tax": null,
        "AmountWithoutVat": "2000.00000000",
        "VatAmount": "160.00000000",
        "VatAmountTwo": "0.00000000",
        "VatAmountThree": "0.00000000",
        "VatAmountFour": "0.00000000",
        "VatRate": "8.00000000",
        "VatRateTwo": null,
        "VatRateThree": null,
        "VatRateFour": null,
        "TaxCode": "61",
        "TaxCode2": null,
        "TaxCode3": null,
        "TaxCode4": null,
        "DeliverySlipNumber": null,
        "Custom1": "1100",
        "Custom2": "000010100042",
        "Custom3": "1000",
        "Custom4": "090002",
        "Custom5": "RINGI",
        "Custom6": null,
        "Custom7": null,
        "Custom8": null,
        "Custom9": null,
        "Custom10": null,
        "Custom11": null,
        "Custom12": null,
        "Custom13": null,
        "Custom14": null,
        "Custom15": null,
        "Custom16": null,
        "Custom17": null,
        "Custom18": null,
        "Custom19": null,
        "Custom20": null,
        "Allocations": {
          "Allocation": [
            {
              "Percentage": "100.00000000",
              "AllocationAccountCode": "731200008",
              "IsTestUser": "1",
              "Custom1": null,
              "Custom2": null,
              "Custom3": null,
              "Custom4": null,
              "Custom5": null,
              "Custom6": null,
              "Custom7": null,
              "Custom8": null,
              "Custom9": null,
              "Custom10": null,
              "Custom11": null,
              "Custom12": null,
              "Custom13": null,
              "Custom14": null,
              "Custom15": null,
              "Custom16": null,
              "Custom17": null,
              "Custom18": null,
              "Custom19": null,
              "Custom20": null
            }
          ]
        }
      }
    ]
  },
  "ID": "68467137F9ED4DD9AA65",
  "URI": "https://www.concursolutions.com/api/v3.0/invoice/paymentrequest/PaymentRequest/68467137F9ED4DD9AA65"
}

I also have tested to POST a Payment Request for LineItem, and it's worked only if I don't include "0" for Custom values. 

{
  "CurrencyCode": "JPY",
  "DataSource": "MAN",
  "LedgerCode": "AX(JP)",
  "CountryCode": "JP",
  "Name": "KS_API_POST",
  "PaymentMethod": "CLIENT",
  "CreatedByUsername": "testuser01@jins.com",
  "InvoiceDate": "2018-02-21 00:00:00.0",
  "PaymentDueDate": "2018-03-03 00:00:00.0",
  "InvoiceAmount": "2000.00000000",
  "OrgUnit1": "1000",
  "OrgUnit2": "0500000000",
  "Custom1": "KOUZA",
  "Custom22": "1000",
  "ExternalPolicyId": "BB015C3A7701469C93B1",
  "VendorRemitAddress": {
    "AddressCode": "0009-825-9044522",
    "VendorCode": "0010520037",
  },
  "LineItems": {
      {
        "ExpenseTypeCode": "2062",
        "Quantity": "1",
        "Description": "SETSUMEI",
        "UnitOfMeasure": null,
        "UnitPrice": "2000.00000000",
        "VatAmount": "160.00000000",
        "Custom1": "1100",
        "Custom2": "000010100042",
        "Custom3": "1000",
        "Custom4": "090002",
        "Custom5": "RINGI"
      }
  }
}

## Pull Request Checklist

**Complete and check all items that are applicable.**

- [ ] Proofread documentation changes for spelling and grammatical errors
- [ ] Used Markdown code blocks for all applicable examples using code
- [ ] Used relative links when linking to other documentation on Developer Center
- [ ] If creating new API reference pages, followed the guidelines stated [in the wiki](https://github.com/concur/developer.concur.com/wiki/Creating-API-Reference-pages)
- [ ] If moving pages, added [page redirects](https://github.com/concur/developer.concur.com/wiki/Adding-Redirects) so users are redirected to the new page
