### PR TITLE
Adding special note to SIWC docs for Expense Only

### DIFF
--- a/src/api-reference/authentication/sign_in_with_concur.markdown
+++ b/src/api-reference/authentication/sign_in_with_concur.markdown
@@ -308,8 +308,10 @@ Depending on the products the customer has enabled, integrations and features av
   - Non-Triplink Access:
     - Travel Profile
     - E-receipt
-- Expense Only Access:
+- Expense Only Access:* 
   - E-receipt
+
+* Special Note: For TripLink Suppliers that support the [Travel Receipts API](https://developer.concur.com/api-reference/travel-receipts/getting-started.html), this API does not support Expense only users. It is recommended that e-receipts be posted for these or all users via the [Receipts API](https://developer.concur.com/api-reference/receipts/get-started.html).
 
 To determine which permissions the user has access to, **each time a user signs in** \*, your application should:
 

--- a/src/api-reference/authentication/sign_in_with_concur.markdown
+++ b/src/api-reference/authentication/sign_in_with_concur.markdown
@@ -311,7 +311,7 @@ Depending on the products the customer has enabled, integrations and features av
 - Expense Only Access:* 
   - E-receipt
 
-* Special Note: For TripLink Suppliers that support the [Travel Receipts API](https://developer.concur.com/api-reference/travel-receipts/getting-started.html), this API does not support Expense only users. It is recommended that e-receipts be posted for these or all users via the [Receipts API](https://developer.concur.com/api-reference/receipts/get-started.html).
+* Special Note: For TripLink Suppliers that support the [Travel Receipts API](/api-reference/travel-receipts/getting-started.html), this API does not support Expense only users. It is recommended that e-receipts be posted for these or all users via the [Receipts API](/api-reference/receipts/get-started.html).
 
 To determine which permissions the user has access to, **each time a user signs in** \*, your application should:
 

--- a/src/api-reference/authentication/sign_in_with_concur.markdown
+++ b/src/api-reference/authentication/sign_in_with_concur.markdown
@@ -311,7 +311,7 @@ Depending on the products the customer has enabled, integrations and features av
 - Expense Only Access:* 
   - E-receipt
 
-* Special Note: For TripLink Suppliers that support the [Travel Receipts API](/api-reference/travel-receipts/getting-started.html), this API does not support Expense only users. It is recommended that e-receipts be posted for these or all users via the [Receipts API](/api-reference/receipts/get-started.html).
+\* Special Note: For TripLink Suppliers that support the [Travel Receipts API](/api-reference/travel-receipts/getting-started.html), this API does not support Expense only users. It is recommended that e-receipts be posted for these or all users via the [Receipts API](/api-reference/receipts/get-started.html).
 
 To determine which permissions the user has access to, **each time a user signs in** \*, your application should:
 


### PR DESCRIPTION
Many triplink suppliers will only support the Travel Receipts API which won't work for expense only users. Adding special note regarding this to "TripLink configurations" section.

## Pull Request Checklist

**Complete and check all items that are applicable.**

- [x] Proofread documentation changes for spelling and grammatical errors
- [x] Used Markdown code blocks for all applicable examples using code
- [x] Used relative links when linking to other documentation on Developer Center
- [na] If creating new API reference pages, followed the guidelines stated [in the wiki](https://github.com/concur/developer.concur.com/wiki/Creating-API-Reference-pages)
- [na] If moving pages, added [page redirects](https://github.com/concur/developer.concur.com/wiki/Adding-Redirects) so users are redirected to the new page
