### PR TITLE
CLQ-64129 ISO Country removed from POS Header

### DIFF
--- a/src/api-reference/direct-connects/hotel-service-2/Headers.markdown
+++ b/src/api-reference/direct-connects/hotel-service-2/Headers.markdown
@@ -1,5 +1,5 @@
 ---
-title: Headers 
+title: Headers
 layout: reference
 ---
 
@@ -24,10 +24,10 @@ Supported Soapactions:
 |--------------|---------------|
 | search       | Used to perform Search  |
 | availability | Used to perform Availability |
-| detail       | Used to perform Hotel Description | 
-| book         | Used to perform Reservation | 
-| read         | Used to perform Read Itinerary | 
-| cancel       | Used to perform Cancel | 
+| detail       | Used to perform Hotel Description |
+| book         | Used to perform Reservation |
+| read         | Used to perform Read Itinerary |
+| cancel       | Used to perform Cancel |
 
 Example HTTP Header from network capture:
 
@@ -77,7 +77,7 @@ Login and password are provided by the Hotel supplier for Concur as API consumer
 
 # OTA Message Headers
 
-Every message must contain the following required attributes and elements.  On top of these each message may specify extra attributes and elements. Refer to a specific messages' page for details. 
+Every message must contain the following required attributes and elements.  On top of these each message may specify extra attributes and elements. Refer to a specific messages' page for details.
 
 ## Request Message Headers
 
@@ -100,11 +100,10 @@ Every message must contain the following required attributes and elements.  On t
 
 **Source**
 
-Concur will always send the ISOCountry and ISO Currency
+Concur will always send the ISO Currency
 
 | Element       | Required | Data Type    | Description |
 |---------------|----------|--------------|-------------|
-| *ISOCountry*  | Y        | ISO3166      | Country code |
 | *ISOCurrency* | Y        | AlphaLength3 | Currency Code |
 | RequestorID   | N        | Complex      | An identifier of the entity making the request (e.g. ATA/IATA/ID number, Electronic Reservation Service Provider (ERSP), Association of British Travel Agents.(ABTA)) |
 


### PR DESCRIPTION
## Pull Request Checklist
#### Complete and check all items that are applicable.
 - [x] Proofread documentation changes for spelling and grammatical errors
 - [ ] Used Markdown code blocks for all applicable examples using code
 - [ ] Used relative links when linking to other documentation on Developer Center
 - [ ] If creating new API reference pages, followed the guidelines stated in the wiki
 - [ ] If moving pages, added page redirects so users are redirected to the new page

Removed ISO Country from the Source Type under POS header, since it is not used anywhere in the HotelService-2.xsd file.