### PR TITLE
Update 2018-05-14-mandatory-content-type-header.markdown

### DIFF
--- a/src/changelog/_posts/2018-05-14-mandatory-content-type-header.markdown
+++ b/src/changelog/_posts/2018-05-14-mandatory-content-type-header.markdown
@@ -10,7 +10,7 @@ tags:
 
 In order to be compliant with the IETF Oauth2 Specification, specifically Appendix B (https://tools.ietf.org/html/draft-ietf-oauth-v2-31#appendix-B) the Authentication team will be releasing an update in the June Release (6/15/2018) that has a potential to break existing clients.
 
-From the above date onwards, all calls to Oauth2's /token endpoint MUST have the content-type header.
+From the above date onwards, all calls to Oauth2's /token and /otp endpoints MUST have the content-type header.
 
 `Content-Type: application/x-www-form-urlencoded`
 


### PR DESCRIPTION
Adding the mention of the "/otp" endpoint as the change also affects this call.

## Pull Request Checklist

**Complete and check all items that are applicable.**

- [x ] Proofread documentation changes for spelling and grammatical errors
- [ ] Used Markdown code blocks for all applicable examples using code
- [ ] Used relative links when linking to other documentation on Developer Center
- [ ] If creating new API reference pages, followed the guidelines stated [in the wiki](https://github.com/concur/developer.concur.com/wiki/Creating-API-Reference-pages)
- [ ] If moving pages, added [page redirects](https://github.com/concur/developer.concur.com/wiki/Adding-Redirects) so users are redirected to the new page
