### PR TITLE
Please remove the / for accuracy

### DIFF
--- a/src/api-reference/expense/expense-report/expense-entry.markdown
+++ b/src/api-reference/expense/expense-report/expense-entry.markdown
@@ -167,7 +167,7 @@ https://www.concursolutions.com/api/v3.0/expense/entries/gWidFO7ikXV66iSvqtG6Yd0
 
 ## <a name="post"></a>Create a new expense entry
 
-    POST  /api/v3.0/expense/entries/
+    POST  /api/v3.0/expense/entries
 
 
 ### Parameters


### PR DESCRIPTION
Developer don't need to post / as below.  

POST  /api/v3.0/expense/entries/

Japanese Vendor developed the program by following this page described.

URL: http://us.api.concursolutions.com/api/v3.0/expense/entries/?user=xxxxx@xxx.com

Response
URI:    https://us.api.concursolutions.com/api/v3.0/expense/entries//gWhbqVfvfcymKn5OAvgZumE2D8$pxr0cjPIg?user=xxxxx@xxx.com

However Concur automatically insert the "/" character between "/api/v3.0/expense/entries" and "{id}". 
So, please remove the "/" character for accuracy.

