### PR TITLE
Security - take out reference to 'sample application connector'

### DIFF
--- a/src/api-reference/callouts/callouts-application-connectors.markdown
+++ b/src/api-reference/callouts/callouts-application-connectors.markdown
@@ -45,8 +45,6 @@ Concur administrators use the **Manage** **Application Connectors** link on the 
 
 Concur will make calls to the application connector's endpoint using SSL. During configuration, Concur will connect to the application connector to validate that its hostname and access credentials are valid.
 
-In the code Concur provides for a sample application connector, credentials are stored in a web configuration file that varies by platform, such as web.xml or web.config. However, if you are hosting the connector, you can customize where and how the credentials are stored by customizing HTTPBasicAuth.java or Authentication.cs.
-
 Concur will not be able to connect to the application connector until a certificate signed by a Certificate Authority (CA) is installed in the application connector. If you are hosting the application connector, you will need to install the signed certificate before Concur can access the connector.
 
 ####  Authentication


### PR DESCRIPTION
Remove paragraph in Security section that references Sample Code provided by Concur.

