### PR TITLE
PurchseOrder V3 API documentation changes for new fields

### DIFF
--- a/src/api-explorer/v3-0/PurchaseOrders.swagger2.json
+++ b/src/api-explorer/v3-0/PurchaseOrders.swagger2.json
@@ -108,7 +108,7 @@
   },
   "definitions": {
     "Allocation": {
-      "required":["Amount", "GrossAmount", "Percentage"],
+      "required":["Amount"],
       "properties": {
         "Amount": {
           "type": "string",
@@ -394,6 +394,10 @@
           "type": "string",
           "description": "Any tax that is associated with the line item."
         },
+        "UnitOfMeasureCode": {
+          "type": "string",
+          "description": "The unit of measure code of the line item."
+        },
         "UnitPrice": {
           "type": "string",
           "description": "The price of each item of the line item."
@@ -534,6 +538,14 @@
           "type": "string",
           "description": "The unique identifier of the resource."
         },
+        "IsTest": {
+          "type": "boolean",
+          "description": "If the purchase order is a test."
+        },
+        "IsChangeOrder": {
+          "type": "boolean",
+          "description": "If the purchase order has a change order or not."
+        },
         "LedgerCode": {
           "type": "string",
           "description": "A code which indicates which company journal the Purchase Order is assigned to. Use GET /purchase order/localizeddata to translate the code into text."
@@ -575,6 +587,10 @@
         "PurchaseOrderNumber": {
           "type": "string",
           "description": "The purchase order number."
+        },
+        "PurchaseRequestNumber": {
+          "type": "string",
+          "description": "The related purchase request number that generated the purchase order."
         },
         "ReceiptType": {
           "type": "string",

--- a/src/api-reference/invoice/v3.purchase-order.markdown
+++ b/src/api-reference/invoice/v3.purchase-order.markdown
@@ -22,7 +22,7 @@ layout: reference
 POST /api/v3.0/invoice/purchaseorders
 ```
 
-Create or update a Purchase Order. Batch processing is not available using the Purchase Order API. Please use CES for batch updates.
+Create or update a Purchase Order. Batch processing is not available using the Purchase Order API. Please use Import Jobs for batch updates.
 
 ### <a name="8"></a>Parameters  
 
@@ -235,15 +235,12 @@ Name|Type|Format|Description
 `Tax`|`string`|-|Any tax that is associated with the line item.
 `UnitOfMeasureCode`|`string`|-|The unit of measure code of the line item.
 `UnitPrice`|`string`|-|**Required** The price of each item of the line item.
-
 `VatAmount`|`string`|-|This field has not been implemented by Purchase Request yet. Any data in this field will be ignored.
 `VatRate`|`string`|-|This field has not been implemented by Purchase Request yet. Any data in this field will be ignored.
 
 #### <a name="allocation"></a>Allocation  
 
 Name|Type|Format|Description
----|---|---|---The purchase request number.
-
 `Amount`|`string`|-|**Required** The total amount of the allocation.
 `Custom1 through Custom20`|`string`|-|A value that can be applied to a custom field 1 that is part of the allocation form.
 `GrossAmount`|`string`|-|The allocation gross amount.

--- a/src/api-reference/invoice/v3.purchase-order.markdown
+++ b/src/api-reference/invoice/v3.purchase-order.markdown
@@ -241,6 +241,7 @@ Name|Type|Format|Description
 #### <a name="allocation"></a>Allocation  
 
 Name|Type|Format|Description
+---|---|---|---
 `Amount`|`string`|-|**Required** The total amount of the allocation.
 `Custom1 through Custom20`|`string`|-|A value that can be applied to a custom field 1 that is part of the allocation form.
 `GrossAmount`|`string`|-|The allocation gross amount.

--- a/src/api-reference/invoice/v3.purchase-order.markdown
+++ b/src/api-reference/invoice/v3.purchase-order.markdown
@@ -51,6 +51,8 @@ Name|Type|Format|Description
   "OrderDate":"2011-08-12T20:17:46.384Z",
 
   "ID": "API101",
+  "IsTest": "false",
+  "IsChangeOrder": "false",
   "LedgerCode": "23",
   "LineItem": [
     {
@@ -66,12 +68,14 @@ Name|Type|Format|Description
       "LineNumber": "1",
       "PurchaseOrderReceiptType": "WQTY",
       "Quantity": "1",
+      "UnitOfMeasureCode":"DA",
       "UnitPrice": "10"
     }
   ],
   "Name": "poName",
   "PolicyExternalID": "PO",
   "PurchaseOrderNumber": "API101",
+  "PurchaseRequestNumber": "100001",
   "ShipToAddress": {
     "Address1": "add1",
     "Address2": "add2",
@@ -163,6 +167,9 @@ Name|Type|Format|Description
 `DiscountPercentage`|`string`|-|The discount from the vendor, if the discount terms are met.
 `DiscountTerms`|`string`|-|The net discount terms that the vendor offers, when discounts apply.
 `ID`|`string`|-|The unique identifier of the resource.
+`IsTest`|`boolean`|-|If the purchase order is a test.
+`IsChangeOrder`|`string`|-|If the purchase order has a change order or not.
+`LedgerCode`|`string`|-|A code which indicates which company journal the Purchase Order is assigned to.
 `LineItem`|`array`|[`LineItem`](#lineItem)|**Required** The line items in a purchase order.
 `Name`|`string`|-|A name for the purchase order.
 `NeededByDate`|`string`|-|The date by which the purchase order must be fulfilled. Format: YYYY-MM-DD
@@ -172,6 +179,7 @@ Name|Type|Format|Description
 `PoVendorTaxId`|`string`|-|The Vendor Tax ID.
 `ProvincialTaxId`|`string`|-|The Vendor Provincial Tax ID.
 `PurchaseOrderNumber`|`string`|-|The purchase order number.
+`PurchaseRequestNumber`|`string`|-|The related purchase request number that generated the purchase order.
 `ReceiptType`|`string`|-|The Purchase Order Receipt type (Deprecated). Use the PurchaseOrderReceiptType at line item level instead.
 `RequestedBy`|`string`|-|The person who requests the goods in the purchase order.
 `RequestedDeliveryDate`|`string`|-|The date the purchase order instructed the vendor to deliver the goods. Format YYYY-MM-DD
@@ -225,18 +233,21 @@ Name|Type|Format|Description
 `RequestedDeliveryDate`|`string`|-|The date the line item of the purchase order instructed the vendor to deliver the goods. Format: YYYY-MM-DD
 `SupplierPartID`|`string`|-|Any number that might help to identify the line item. This could be a value such as the vendor's part number or even the manufacturer number.
 `Tax`|`string`|-|Any tax that is associated with the line item.
+`UnitOfMeasureCode`|`string`|-|The unit of measure code of the line item.
 `UnitPrice`|`string`|-|**Required** The price of each item of the line item.
+
 `VatAmount`|`string`|-|This field has not been implemented by Purchase Request yet. Any data in this field will be ignored.
 `VatRate`|`string`|-|This field has not been implemented by Purchase Request yet. Any data in this field will be ignored.
 
 #### <a name="allocation"></a>Allocation  
 
 Name|Type|Format|Description
----|---|---|---
+---|---|---|---The purchase request number.
+
 `Amount`|`string`|-|**Required** The total amount of the allocation.
 `Custom1 through Custom20`|`string`|-|A value that can be applied to a custom field 1 that is part of the allocation form.
-`GrossAmount`|`string`|-|**Required** The allocation gross amount.
-`Percentage`|`string`|-|**Required** The allocation percentage.
+`GrossAmount`|`string`|-|The allocation gross amount.
+`Percentage`|`string`|-|The allocation percentage.
 
 #### <a name="ship-to-address"></a>ShipToAddress  
 


### PR DESCRIPTION
As part of V3 Purchase Order we introduced some changes. It is already live in Sep SU, this is to update the customer facing documentation.

Related development Jira - INV-28161