### PR TITLE
Make Concur Developer Portal --> SAP Concur Developer Center

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # Site settings
-title: Concur Developer Portal
+title: SAP Concur Developer Center
 email: devx@concur.com
 description: Concur docs provides comprehensive information on working with the Concur platform
 baseurl: "" # the subpath of your site, /developer.concur.com

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -1,7 +1,7 @@
 {% if site.data.branch.branchname != 'livesite' %}
-  <title>[{{ site.data.branch.branchname }}] Concur Developer Portal | {{ page.title }}</title>
+  <title>[{{ site.data.branch.branchname }}] SAP Concur Developer Center | {{ page.title }}</title>
 {% else %}
-  <title>Concur Developer Portal | {{ page.title }}</title>
+  <title>SAP Concur Developer Center | {{ page.title }}</title>
 {% endif %}
 
 <!-- Meta -->
@@ -38,7 +38,7 @@
   <!-- <link href="{{ site.baseurl }}/swagger-ui/css/ecebook.css" rel="stylesheet" type="text/css"/> -->
 {% endif %}
 
-<link rel="alternate" type="application/rss+xml" title="Concur Developer Portal RSS" href="/feed.xml" />
+<link rel="alternate" type="application/rss+xml" title="SAP Concur Developer Center RSS" href="/feed.xml" />
 
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -11,7 +11,7 @@
         </button>
         <a class="navbar-brand" href="{{ site.baseurl }}/">
           <img src="{{ site.baseurl }}/assets/img/concur_logo_white_gold.png" alt="Logo">
-          <div class="app-name">Developer Center</div>
+          <div class="app-name">SAP Concur Developer Center</div>
         </a>
       </div>
       <!-- Collect the nav links, forms, and other content for toggling -->

--- a/src/api-guides/travel/get-itinerary.markdown
+++ b/src/api-guides/travel/get-itinerary.markdown
@@ -191,7 +191,7 @@ Amadeus e-Travel Management (AeTM) is an online self-booking tool integrated wit
 
 #### Subscribe and Unsubscribe
 
-Concur Travel Suppliers and Travel Management Companies may need to know how to post a company notification subscription for itinerary changes. Use the information which follows to guide you. More information on these topics can be found in the Concur Developer Portal in the resource: [Subscribe or unsubscribe from notifications]( /api-reference/travel-profile/04-notification-company-resource.html).
+Concur Travel Suppliers and Travel Management Companies may need to know how to post a company notification subscription for itinerary changes. Use the information which follows to guide you. More information on these topics can be found in the SAP Concur Developer Center in the resource: [Subscribe or unsubscribe from notifications]( /api-reference/travel-profile/04-notification-company-resource.html).
 
 To subscribe to notifications to be alerted whenever employees who have booked travel through Concur change their travel plans by adding, modifying or canceling an itinerary is referred to as a **POST Company Notification Subscription for Itinerary Changes request**.
 

--- a/src/tools-support/release-notes/dev-platform-2016-11-01.markdown
+++ b/src/tools-support/release-notes/dev-platform-2016-11-01.markdown
@@ -35,4 +35,4 @@ Attendee / Attendee Type|Delete Attendee Type v3.0
 
 This update removes outdated or unused APIs and API functions.
 
-Additional information is available on the Concur Developer Portal: [https://developer.concur.com](https://developer.concur.com/).
+Additional information is available on the SAP Concur Developer Center: [https://developer.concur.com](https://developer.concur.com/).

--- a/vagrant/nginx/bug_bounty.txt
+++ b/vagrant/nginx/bug_bounty.txt
@@ -1,3 +1,3 @@
 Hello security researchers. The private key in this directory is for running the
-Concur Developer Center locally. This poses no security risk and will not be
+SAP Concur Developer Center locally. This poses no security risk and will not be
 accepted for bounty.


### PR DESCRIPTION
Browsing with Brave which has a nice feature pulling metadata out of the pages to make the address bar friendlier, for example:

developer.concur.com | Concur Developer Portal | Home
developer.concur.com | Concur Developer Portal | Receipts v4 - Get Started

This pull request updates so that reads...

developer.concur.com | SAP Concur Developer Center | Home

...which is consistent with the other naming / branding on the site.