### PR TITLE
Changes requested by Laurel.

### DIFF
--- a/src/manage-apps/go-to-market.html
+++ b/src/manage-apps/go-to-market.html
@@ -20,7 +20,8 @@ layout: default
           <div class="row">
             <div class="col-md-12">
               <h2>Overview</h2>
-              <p>Now that you’re a SAP Concur App Center partner it’s time to prepare for your launch! This page will provide you with the resources needed for your initial launch as well as ongoing reference.</p>
+              <p>Now that you’re a SAP Concur App Center partner, it’s time to prepare for your launch!</p>
+              <p>This page will provide you with the resources needed for your initial launch as well as ongoing reference.</p>
               <div class="fine-print">
                 <p>*If you’re not yet a SAP Concur App Center partner please <a href="mailto:bizdev@concur.com" onClick="ga('send', 'event', 'Email', 'Send', 'mailto:bizdev@concur.com', {nonInteraction: true});">contact our Business Development team</a> to discuss an agreement.</p>
               </div>


### PR DESCRIPTION
From @LaurelC3:

* Could we add a comma in “Now that you’re a SAP Concur App Center partner, it’s time to prepare for your launch!”? (After partner).
* The blue space looks really big. I’d see if it’s possible to make it a little shorter. If not, I’d move “This page will provide you with the resources needed for your initial launch as well as ongoing reference” down to a new paragraph with a  space between both sentences.

Can't really change the amount of blue space without touching the CSS so probably best to leave alone unless we are ready to affect some bigger stylesheet changes.