### PR TITLE
Fixing formatting

### DIFF
--- a/src/api-reference/common/event-pubsub/travel-search-event.markdown
+++ b/src/api-reference/common/event-pubsub/travel-search-event.markdown
@@ -50,7 +50,7 @@ Name|Type|Format|Description
 `id`|`String`|GUID|Uniquely identifies the event.
 `correlationId`|String|GUID|Uniquely identifies the air search request.
 `eventType`|String|-|Identifies the search event type. for air search it is travelSearchAir
-`topic`|String|-|Topic for subscription for air hotel and car search this will be : concur.travel.search
+`topic`|String|concur.travel.search|Topic for subscription for air hotel and car search this will be : concur.travel.search
 `subTopic`|String| -|identify sub catagory for air search it can be :  <br>-airshop.v1.schedule <br>-airshop.v1.price
 `timeStamp`|String|date/time|Search event time, UTC.
 `facts`|`Object`|[Air Search Facts](#schema-air-search-facts)| Facts for air search.

--- a/src/api-reference/common/event-pubsub/travel-search-event.markdown
+++ b/src/api-reference/common/event-pubsub/travel-search-event.markdown
@@ -31,7 +31,7 @@ If the subscriber action on the event is non-idempotent or expensive guard again
 
 ### <a name="event-subscription-service-behavior"></a>Event Subscription Service (ESS) Behavior
 The Event Subscription service has the following characteristics from the subscriber perspective.
-* Requests will come from [us | emea | cn].api.concursolutions.com
+* Requests will come from us.api.concursolutions.com, emea.api.concursolutions.com or cn.api.concursolutions.com
 * Requests will be re-tried when subscriber responds with HTTP Response Code(s): 5xx, 401, 403 and 429
 * Requests will not be re-tried when subscriber responds with HTTP Response Code(s):
   * 2xx – Indicates successful receipt of the event

--- a/src/api-reference/common/event-pubsub/travel-search-event.markdown
+++ b/src/api-reference/common/event-pubsub/travel-search-event.markdown
@@ -16,7 +16,7 @@ Subscribers to this event will receive search criteria for travel searches perfo
 
 ## <a name="subscribing"></a>Subscribing
 
-For partners, please work with your technical enablement contact to subscribe to this event.
+For partners, please work with your technical enablement contact to subscribe to this topic 'concur.travel.search'.
 
 You must provide an HTTPS server endpoint that will accept the event payload described below.
 
@@ -50,7 +50,7 @@ Name|Type|Format|Description
 `id`|`String`|GUID|Uniquely identifies the event.
 `correlationId`|String|GUID|Uniquely identifies the air search request.
 `eventType`|String|-|Identifies the search event type. for air search it is travelSearchAir
-`topic`|String|concur.travel.search|Topic for subscription for air hotel and car search this will be : concur.travel.search
+`topic`|String|-|Topic for subscription for air hotel and car search this will be : concur.travel.search
 `subTopic`|String| -|identify sub catagory for air search it can be :  <br>-airshop.v1.schedule <br>-airshop.v1.price
 `timeStamp`|String|date/time|Search event time, UTC.
 `facts`|`Object`|[Air Search Facts](#schema-air-search-facts)| Facts for air search.


### PR DESCRIPTION
Adding back the travel search topic to the "subscribe" header as it was confusing.

Fixing table formatting around the base URIs.