### PR TITLE
Updated the description for userIDs

### DIFF
--- a/src/api-reference/common/event-pubsub/travel-search-event.markdown
+++ b/src/api-reference/common/event-pubsub/travel-search-event.markdown
@@ -107,7 +107,7 @@ Name|Type|Format|Description
 Name|Type|Format|Description
 ---|---|---|---
 `companyId`|`String`|GUID|Uniquely identifies the company of the traveler.
-`userId`|`String`|GUID|Uniquely identifies the user performing the search. <br>*NOTES:* In cases where the individual is booking on behalf of a guest, this is the user performing the search (e.g. the arranger).</br><br>Unlike Air, Hotel will not return arranger information.</br>
+`userId`|`String`|GUID|Uniquely identifies the user performing the search. <br> *NOTES:* </br>In cases where the individual is booking on behalf of a guest, this is the user performing the search (e.g. the arranger).  Unlike Air, Hotel will not return arranger information.
 `refPointLatitude`|`Number`|Double | Search location, latitude.
 `refPointLongitude`|`Number`|Double | Search location, longitude.
 `refPointName`|`String`|-|Reference point location name.

--- a/src/api-reference/common/event-pubsub/travel-search-event.markdown
+++ b/src/api-reference/common/event-pubsub/travel-search-event.markdown
@@ -107,7 +107,7 @@ Name|Type|Format|Description
 Name|Type|Format|Description
 ---|---|---|---
 `companyId`|`String`|GUID|Uniquely identifies the company of the traveler.
-`userId`|`String`|GUID|Uniquely identifies the user performing the search. <br> *NOTES:* </br>In cases where the individual is booking on behalf of a guest, this is the user performing the search (e.g. the arranger).  Unlike Air, Hotel will not return arranger information.
+`userId`|`String`|GUID|Uniquely identifies the user performing the search. <br> *NOTES:* </br>In cases where the individual is booking on behalf of a guest, a traveler without a Concur Travel profile, this is the user performing the search (e.g. the arranger).  In cases where the individual is booking on behalf of a traveler that does have a Concur profile (e.g. an arranger), this will be the arranger's ID and not the traveler.
 `refPointLatitude`|`Number`|Double | Search location, latitude.
 `refPointLongitude`|`Number`|Double | Search location, longitude.
 `refPointName`|`String`|-|Reference point location name.

--- a/src/api-reference/common/event-pubsub/travel-search-event.markdown
+++ b/src/api-reference/common/event-pubsub/travel-search-event.markdown
@@ -107,7 +107,7 @@ Name|Type|Format|Description
 Name|Type|Format|Description
 ---|---|---|---
 `companyId`|`String`|GUID|Uniquely identifies the company of the traveler.
-`userId`|`String`|GUID|Uniquely identifies the user performing the search. *NOTE:* In cases where the individual is booking on behalf of a guest, this is the user performing the search (e.g. the arranger).<br>Unlike Air, Hotel will not return arranger information.</br>
+`userId`|`String`|GUID|Uniquely identifies the user performing the search. <br>*NOTES:* In cases where the individual is booking on behalf of a guest, this is the user performing the search (e.g. the arranger).</br><br>Unlike Air, Hotel will not return arranger information.</br>
 `refPointLatitude`|`Number`|Double | Search location, latitude.
 `refPointLongitude`|`Number`|Double | Search location, longitude.
 `refPointName`|`String`|-|Reference point location name.

--- a/src/api-reference/common/event-pubsub/travel-search-event.markdown
+++ b/src/api-reference/common/event-pubsub/travel-search-event.markdown
@@ -107,7 +107,7 @@ Name|Type|Format|Description
 Name|Type|Format|Description
 ---|---|---|---
 `companyId`|`String`|GUID|Uniquely identifies the company of the traveler.
-`userId`|`String`|GUID|Uniquely identifies the user performing the search. <br> *NOTES:* </br>In cases where the individual is booking on behalf of a guest, a traveler without a Concur Travel profile, this is the user performing the search (e.g. the arranger).  In cases where the individual is booking on behalf of a traveler that does have a Concur profile (e.g. an arranger), this will be the arranger's ID and not the traveler.
+`userId`|`String`|GUID|Uniquely identifies the user performing the search. <br> *NOTES:* </br>In cases where the individual is booking on behalf of a guest, a traveler without a Concur Travel profile, this is the user performing the search (e.g. the arranger).  In cases where the individual is booking on behalf of a traveler that does have a Concur profile (e.g. an arranger), this will be the traveler's ID.
 `refPointLatitude`|`Number`|Double | Search location, latitude.
 `refPointLongitude`|`Number`|Double | Search location, longitude.
 `refPointName`|`String`|-|Reference point location name.

--- a/src/api-reference/common/event-pubsub/travel-search-event.markdown
+++ b/src/api-reference/common/event-pubsub/travel-search-event.markdown
@@ -107,7 +107,7 @@ Name|Type|Format|Description
 Name|Type|Format|Description
 ---|---|---|---
 `companyId`|`String`|GUID|Uniquely identifies the company of the traveler.
-`userId`|`String`|GUID|Uniquely identifies the user performing the search. *NOTE:* In cases where the individual is booking on behalf of a guest, this is the user performing the search.
+`userId`|`String`|GUID|Uniquely identifies the user performing the search. *NOTE:* In cases where the individual is booking on behalf of a guest, this is the user performing the search (e.g. the arranger).
 Unlike Air, Hotel will not return arranger information.
 `refPointLatitude`|`Number`|Double | Search location, latitude.
 `refPointLongitude`|`Number`|Double | Search location, longitude.

--- a/src/api-reference/common/event-pubsub/travel-search-event.markdown
+++ b/src/api-reference/common/event-pubsub/travel-search-event.markdown
@@ -61,7 +61,7 @@ Name|Type|Format|Description
 ---|---|---|---
 `companyId`|`String`|GUID|Uniquely identifies the company of the traveler.
 `userId`|`String`|GUID|Uniquely identifies the user performing the search. *NOTE:* In the event travel is booked by an arranger, this is the traveler. In cases where the individual is booking on behalf of a guest, this is the user performing the search.
-`arrangerUserId`|`String`|GUID|Uniquely identifies the user arranging the trip.
+`arrangerUserId`|`String`|GUID|If the user is also the traveler, this value will be the same as the userID above. If an arranger is booking on behalf of the traveler, this will uniquely identify the user arranging the trip. 
 `searchLegs`|`String`|RoundTrip, MultiSeg, OneWay | Type of air search.
 `isGuestBooking`|`boolean`|-|Identifies if the booking is guest or not.
 `isFlexFaring`|`boolean`|-|Identifies if search is for flex faring.
@@ -107,7 +107,8 @@ Name|Type|Format|Description
 Name|Type|Format|Description
 ---|---|---|---
 `companyId`|`String`|GUID|Uniquely identifies the company of the traveler.
-`userId`|`String`|GUID|Uniquely identifies the user performing the search. *NOTE:* In the event travel is booked by an arranger, this is the traveler. In cases where the individual is booking on behalf of a guest, this is the user performing the search.
+`userId`|`String`|GUID|Uniquely identifies the user performing the search. *NOTE:* In cases where the individual is booking on behalf of a guest, this is the user performing the search.
+Unlike Air, Hotel will not return arranger information.
 `refPointLatitude`|`Number`|Double | Search location, latitude.
 `refPointLongitude`|`Number`|Double | Search location, longitude.
 `refPointName`|`String`|-|Reference point location name.

--- a/src/api-reference/common/event-pubsub/travel-search-event.markdown
+++ b/src/api-reference/common/event-pubsub/travel-search-event.markdown
@@ -107,8 +107,7 @@ Name|Type|Format|Description
 Name|Type|Format|Description
 ---|---|---|---
 `companyId`|`String`|GUID|Uniquely identifies the company of the traveler.
-`userId`|`String`|GUID|Uniquely identifies the user performing the search. *NOTE:* In cases where the individual is booking on behalf of a guest, this is the user performing the search (e.g. the arranger).
-Unlike Air, Hotel will not return arranger information.
+`userId`|`String`|GUID|Uniquely identifies the user performing the search. *NOTE:* In cases where the individual is booking on behalf of a guest, this is the user performing the search (e.g. the arranger).<br>Unlike Air, Hotel will not return arranger information.</br>
 `refPointLatitude`|`Number`|Double | Search location, latitude.
 `refPointLongitude`|`Number`|Double | Search location, longitude.
 `refPointName`|`String`|-|Reference point location name.


### PR DESCRIPTION
Updated the description for userID and arrangerID in air and hotel based on behavior.
For air, the arrangerID = userID when traveler is booking for themselves. Otherwise it is the arrangerID.
For hotel, arrangerID will never be provided.

