### PR TITLE
Update v4.invoice-pay.markdown

### DIFF
--- a/src/api-reference/invoice/v4.invoice-pay.markdown
+++ b/src/api-reference/invoice/v4.invoice-pay.markdown
@@ -49,7 +49,7 @@ This API supports only Company access tokens.
 Payment providers can use this endpoint to get a list of payments.
 * This method will return all payments with a status [PENDING_RETRIEVAL](#schema-payment-update-status) and payment method `PAVPVD`. After an invoice is approved and extracted it will be converted into a payment with status [PENDING_RETRIEVAL](#schema-payment-update-status).
 * It returns a maximum of 500 records at a time. In order to ensure that all payments are retrieved, call this method until you receive an empty payment in the response.
-* The payment provider will need to acknowledge that payments were received, using [Updating a Payment With Status](#updating-payment) and updating the status of the payment to [RETRIEVED](#schema-payment-update-status).
+* The payment provider will need to acknowledge that payments were received, using [Updating a Payment With Status](#updating-payment) and updating the status of the payment to any status other than [PENDING_RETRIEVAL](#schema-payment-update-status).
 
 ### Request
 

--- a/src/api-reference/invoice/v4.invoice-pay.markdown
+++ b/src/api-reference/invoice/v4.invoice-pay.markdown
@@ -41,10 +41,6 @@ Name|Description|Endpoint
 `invoice.providerpayment.write`|Read access to pending payments, and write access to payment status|GET,POST
 `company.read`|Required to get the SAP Concur company identifier|GET
 
-## <a name="dependencies"></a>Dependencies
-
-The Concur Invoice client must have purchased and configured Invoice Pay to use this API.
-
 ## <a name="access-token-usage"></a>Access Token Usage
 
 This API supports only Company access tokens.

--- a/src/api-reference/invoice/v4.invoice-pay.markdown
+++ b/src/api-reference/invoice/v4.invoice-pay.markdown
@@ -40,7 +40,7 @@ Name|Description|Endpoint
 ---|---|---
 `invoice.providerpayment.write`|Read access to pending payments, and write access to payment status|GET,POST
 
-## <a name="scope-usage"></a>Scope Usage
+## <a name="dependencies"></a>Dependencies
 
 This API can only be used with SAP Concur clients who have purchased Concur Invoice.
 

--- a/src/api-reference/invoice/v4.invoice-pay.markdown
+++ b/src/api-reference/invoice/v4.invoice-pay.markdown
@@ -40,6 +40,10 @@ Name|Description|Endpoint
 ---|---|---
 `invoice.providerpayment.write`|Read access to pending payments, and write access to payment status|GET,POST
 
+## <a name="scope-usage"></a>Scope Usage
+
+This API can only be used with SAP Concur clients who have purchased Concur Invoice.
+
 ## <a name="access-token-usage"></a>Access Token Usage
 
 This API supports only Company access tokens.

--- a/src/api-reference/invoice/v4.invoice-pay.markdown
+++ b/src/api-reference/invoice/v4.invoice-pay.markdown
@@ -39,7 +39,6 @@ SAP Concur partners with external payment providers for processing invoice payme
 Name|Description|Endpoint
 ---|---|---
 `invoice.providerpayment.write`|Read access to pending payments, and write access to payment status|GET,POST
-`company.read`|Required to get the SAP Concur company identifier|GET
 
 ## <a name="access-token-usage"></a>Access Token Usage
 


### PR DESCRIPTION
We don't have dependency on Invoice Pay being enabled for the APIs.
