### PR TITLE
CLQ-75952 - Add missing field in Reservation

### DIFF
--- a/src/api-reference/direct-connects/hotel-service-2/Reservation.markdown
+++ b/src/api-reference/direct-connects/hotel-service-2/Reservation.markdown
@@ -330,10 +330,11 @@ NamePrefix     |
 
 **Note:** This structure is used in both request and response. Different elements are used in each of them.
 
-| Element     | Required | Data Type | Description |
-|-------------|----------|-----------|-------------|
-| Memberships | N        | Complex   | (request only) A collection of Memberships, provides a list of reward programs like e.g. loyalty cards. |
-| Comments    | N        | Complex   | (response only) A collection of Comments, provides a list of arbitrary reservation comments like e.g. modification code. |
+| Element           | Required | Data Type | Description |
+|-------------------|----------|-----------|-------------|
+| Memberships       | N        | Complex   | (request only) A collection of Memberships, provides a list of reward programs like e.g. loyalty cards. |
+| Comments          | N        | Complex   | (response only) A collection of Comments, provides a list of arbitrary reservation comments like e.g. modification code. |
+| BasicPropertyInfo | N        | Complex   | See Availability |
 
 
 **Memberships**


### PR DESCRIPTION
Adding BasicPropertyInfo node missing under ResGlobalInfo (changed in XSD spec from mandatory to optional in CLQ-75952).
