### PR TITLE
Update links to correct version of auth

### DIFF
--- a/src/api-reference/travel-profile/00-profile-services.markdown
+++ b/src/api-reference/travel-profile/00-profile-services.markdown
@@ -46,7 +46,7 @@ The developer should email [ConcurConnectTech@concur.com][7] and ask to be regis
 Travel supplier or TMC partner applications must complete the [Concur application review process][8] before they can access production user data. Travel suppliers can only access Form of Payment information for the type of travel that they supply. Suppliers can only update Loyalty Program information for the programs that they manage. TMCs can access all the user's Travel Profile data, regardless of vendor.
 
 
-[1]: /api-reference/authentication/apidoc.html
+[1]: /api-reference/authentication/authorization-pre-2017.html
 [2]: /api-reference/travel-profile/01-profile-resource.html
 [3]: /api-reference/travel-profile/02-form-payment-resource.html
 [4]: /api-reference/travel-profile/03-loyalty-program-resource.html

--- a/src/api-reference/travel-profile/04-notification-company-resource.markdown
+++ b/src/api-reference/travel-profile/04-notification-company-resource.markdown
@@ -182,6 +182,6 @@ The partner can use this information to make a Get Travel Profile request.
 
 `200 OK`
 
-[1]: /api-reference/authentication/apidoc.html
+[1]: /api-reference/authentication/authorization-pre-2017.html
 [2]: https://developer.concur.com/reference/http-codes
 [3]: https://developer.concur.com/travel-profile/profile-resource/get-travel-profile

--- a/src/api-reference/travel-profile/05-notification-user-resource.markdown
+++ b/src/api-reference/travel-profile/05-notification-user-resource.markdown
@@ -156,7 +156,7 @@ Subscribes or unsubscribes the travel supplier from notifications when the user'
 #### Headers
 
 ##### Authorization header
-Required. Authorization header with OAuth token for the desired Concur user. This token is granted as part of the [OAuth 2.0 Web flow authorization process](/api-reference/authentication/apidoc.html).
+Required. Authorization header with OAuth token for the desired Concur user. This token is granted as part of the [OAuth 2.0 Web flow authorization process](/api-reference/authentication/authorization-pre-2017.html).
 
 ###  Request
 


### PR DESCRIPTION
Note that the links to auth content in these files pointed to new auth, which the travel profile team has confirmed Notification services doesn't support. 