### PR TITLE
Remove pre-release status from Hotel Service 2

### DIFF
--- a/src/_data/sidebars/api-reference.yml
+++ b/src/_data/sidebars/api-reference.yml
@@ -95,8 +95,8 @@
         url: /api-reference/direct-connects/hotel-service-2/Read-Itinerary.html
       - title: Cancel
         url: /api-reference/direct-connects/hotel-service-2/Cancel.html
-      - title: FAQ
-        url: /api-reference/direct-connects/hotel-service-2/FAQ.html
+      - title: Virtual Payment
+        url: /api-reference/direct-connects/hotel-service-2/V-payment.html
       - title: Appendix
         url: /api-reference/direct-connects/hotel-service-2/Appendix.html
       - title: XSD-schema

--- a/src/api-reference/direct-connects/hotel-service-2/Appendix.markdown
+++ b/src/api-reference/direct-connects/hotel-service-2/Appendix.markdown
@@ -39,11 +39,46 @@ layout: reference
 
 ### Response
 ```xml
-<search response goes here> add a complete samples folder so store the huge search response
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <SOAP-ENV:Header xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"/>
+  <soap:Body>
+    <OTA_HotelSearchRS xmlns="http://www.opentravel.org/OTA/2003/05" xmlns:ns2="http://www.concur.com/webservice/auth" AltLangID="fr" EchoToken="FC6F5CDE-2D55-49A4-AE22-056AF980ADF4" PrimaryLangID="fr" Version="4">
+      <Success/>
+      <Properties>
+        <Property ChainName="Appart City" HotelCode="399671" HotelName="Appart'City Aix en Provence - La Duranne Residence de Tourisme">
+          <Position Latitude="43.49205" Longitude="5.351965"/>
+          <Address>
+            <AddressLine>300 avenue du Grand Vallat</AddressLine>
+            <CityName>Les Milles</CityName>
+            <PostalCode>13290</PostalCode>
+            <CountryName Code="FR">French Republic France</CountryName>
+          </Address>
+          <Award Rating="2"/>
+          <HotelAmenity Code="68"/>
+          <HotelAmenity Code="198"/>
+          <HotelAmenity Code="71"/>
+          <HotelAmenity Code="101"/>
+          <HotelAmenity Code="33"/>
+          <Policy CheckInTime="14:00:00" CheckOutTime="12:00:00"/>
+          <TPA_Extensions>
+            <HotelPreference>not_preferred</HotelPreference>
+            <TPA_HotelPreviewImageURI>
+              <URL>https://foto.hrsstatic.com/fotos/1/3/75/75/80/FFFFFF/http%3A%2F%2Ffoto-origin.hrsstatic.com%2Ffoto%2F3%2F9%2F9%2F6%2Fteaser_399671.jpg/v1M9Y02mJkgafy7d97qkhw%3D%3D/128%2C85/6/AppartCity_Aix_en_Provence_La_Duranne_Residence_de_Tourisme-Les_Milles_Aix-en-Provence-Exterior_view-3-399671.jpg</URL>
+            </TPA_HotelPreviewImageURI>
+          </TPA_Extensions>
+        </Property>
+        <Property>
+          ... and another properties follow here for all the returned hotels
+        </Property>
+      </Properties>
+    </OTA_HotelSearchRS>
+  </soap:Body>
+</soap:Envelope>
 ```
 
+# Availability
 
-The initial Search request is followed up by an multi-property Availability request.  In the example request below Concur requests the availability for 13 properties.  This could because the initial search only yielded 13 properties or the configuration per vendor is set to request availability for a maximum of 13 properties.
+The initial Search request (see above) is followed up by an multi-property Availability request.  In the example request below Concur requests the availability for 13 properties.  This could because the initial search only yielded 13 properties or the configuration per vendor is set to request availability for a maximum of 13 properties.
 
 ### Request
 
@@ -124,38 +159,202 @@ The initial Search request is followed up by an multi-property Availability requ
 ### Response
 
 ```xml
-<response goes here>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <SOAP-ENV:Header xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"/>
+  <soap:Body>
+    <OTA_HotelAvailRS xmlns="http://www.opentravel.org/OTA/2003/05" xmlns:ns2="http://www.concur.com/webservice/auth" AltLangID="fr" EchoToken="FC6F5CDE-2D55-49A4-AE22-056AF980ADF4" PrimaryLangID="fr" Version="5">
+      <Success/>
+      <RoomStays>
+        <RoomStay>
+          <RoomTypes>
+            <RoomType RoomID="b3da298f">
+              <RoomDescription>
+                <Text>La chambre standard est équipée de douche/WC ou de baignoire/WC.</Text>
+              </RoomDescription>
+              <Amenities>
+                <Amenity ExistsCode="1" RoomAmenity="55"/>
+                <Amenity ExistsCode="1" RoomAmenity="56"/>
+                <Amenity ExistsCode="1" RoomAmenity="4"/>
+                <Amenity ExistsCode="1" RoomAmenity="28"/>
+                <Amenity ExistsCode="1" RoomAmenity="210"/>
+                <Amenity ExistsCode="1" RoomAmenity="92"/>
+                <Amenity ExistsCode="1" RoomAmenity="2"/>
+                <Amenity ExistsCode="1" RoomAmenity="126"/>
+                <Amenity ExistsCode="1" RoomAmenity="19"/>
+                <Amenity ExistsCode="1" RoomAmenity="13"/>
+                <Amenity ExistsCode="1" RoomAmenity="96"/>
+                <Amenity ExistsCode="1" RoomAmenity="50"/>
+                <Amenity ExistsCode="1" RoomAmenity="69"/>
+                <Amenity ExistsCode="1" RoomAmenity="107"/>
+                <Amenity ExistsCode="1" RoomAmenity="10"/>
+              </Amenities>
+            </RoomType>
+          </RoomTypes>
+          <RatePlans>
+            <RatePlan AvailabilityStatus="AvailableForSale" PrepaidIndicator="false" RatePlanID="TOGG3BU">
+              <Guarantee GuaranteeType="GuaranteeRequired">
+                <Deadline AbsoluteDeadline="2019-05-08T23:59:59"/>
+              </Guarantee>
+              <CancelPenalties>
+                <CancelPenalty NonRefundable="false">
+                  <Deadline AbsoluteDeadline="2019-05-08T23:59:59" OffsetDropTime="BeforeArrival" OffsetTimeUnit="Day" OffsetUnitMultiplier="14"/>
+                </CancelPenalty>
+              </CancelPenalties>
+              <MealsIncluded Breakfast="false" Dinner="false" Lunch="false"/>
+            </RatePlan>
+          </RatePlans>
+          <RoomRates>
+            <RoomRate RatePlanID="TOGG3BU" RoomID="b3da298f">
+              <Rates>
+                <Rate ChargeType="18" GuaranteedInd="true" NumberOfUnits="1" RateTimeUnit="FullDuration" RoomPricingType="Per stay" UnitMultiplier="1">
+                  <PaymentPolicies>
+                    <GuaranteePayment>
+                      <AcceptedPayments>
+                        <AcceptedPayment>
+                          <PaymentCard>
+                            <CardType>VISA</CardType>
+                          </PaymentCard>
+                        </AcceptedPayment>
+                      </AcceptedPayments>
+                    </GuaranteePayment>
+                    <GuaranteePayment>
+                      <AcceptedPayments>
+                        <AcceptedPayment>
+                          <PaymentCard>
+                            <CardType>Mastercard</CardType>
+                          </PaymentCard>
+                        </AcceptedPayment>
+                      </AcceptedPayments>
+                    </GuaranteePayment>
+                  </PaymentPolicies>
+                  <Total AmountAfterTax="161.10" AmountBeforeTax="152.70" CurrencyCode="EUR" DecimalPlaces="2"/>
+                  <RateDescription>
+                    <Text>Tarif promotionnel</Text>
+                    <Text>Gratuit pour les clients HRS: Quotidien gratuit, Parking attenant à l'hôtel</Text>
+                  </RateDescription>
+                </Rate>
+              </Rates>
+            </RoomRate>
+          </RoomRates>
+          <GuestCounts>
+            <GuestCount Count="1"/>
+          </GuestCounts>
+          <TimeSpan End="2019-05-23" Start="2019-05-22"/>
+          <BasicPropertyInfo HotelCode="36151" HotelName="Château de la Pioline">
+            <Address>
+              <AddressLine>260 Rue Guillaume du Vair</AddressLine>
+              <CityName>AIX EN PROVENCE</CityName>
+              <PostalCode>13546</PostalCode>
+              <CountryName Code="FR">French Republic France</CountryName>
+            </Address>
+            <ContactNumbers>
+              <ContactNumber PhoneNumber="33442522727"/>
+            </ContactNumbers>
+          </BasicPropertyInfo>
+        </RoomStay>
+        <RoomStay>
+          <RoomTypes>
+            <RoomType RoomID="f7631619">
+              <RoomDescription>
+                <Text>La chambre standard est équipée de douche/WC ou de baignoire/WC.</Text>
+              </RoomDescription>
+              <Amenities>
+                <Amenity ExistsCode="1" RoomAmenity="55"/>
+                <Amenity ExistsCode="1" RoomAmenity="56"/>
+                <Amenity ExistsCode="1" RoomAmenity="4"/>
+                <Amenity ExistsCode="1" RoomAmenity="28"/>
+                <Amenity ExistsCode="1" RoomAmenity="210"/>
+                <Amenity ExistsCode="1" RoomAmenity="92"/>
+                <Amenity ExistsCode="1" RoomAmenity="2"/>
+                <Amenity ExistsCode="1" RoomAmenity="126"/>
+                <Amenity ExistsCode="1" RoomAmenity="19"/>
+                <Amenity ExistsCode="1" RoomAmenity="13"/>
+                <Amenity ExistsCode="1" RoomAmenity="96"/>
+                <Amenity ExistsCode="1" RoomAmenity="50"/>
+                <Amenity ExistsCode="1" RoomAmenity="69"/>
+                <Amenity ExistsCode="1" RoomAmenity="107"/>
+                <Amenity ExistsCode="1" RoomAmenity="10"/>
+              </Amenities>
+            </RoomType>
+          </RoomTypes>
+          <RatePlans>
+            <RatePlan AvailabilityStatus="AvailableForSale" PrepaidIndicator="false" RatePlanID="MB4YV34">
+              <Guarantee GuaranteeType="Deposit"/>
+              <CancelPenalties>
+                <CancelPenalty NonRefundable="true">
+                  <Deadline AbsoluteDeadline="2019-04-15T12:51:47"/>
+                </CancelPenalty>
+              </CancelPenalties>
+              <MealsIncluded Breakfast="false" Dinner="false" Lunch="false"/>
+            </RatePlan>
+          </RatePlans>
+          <RoomRates>
+            <RoomRate RatePlanID="MB4YV34" RoomID="f7631619">
+              <Rates>
+                <Rate ChargeType="18" GuaranteedInd="true" NumberOfUnits="1" RateTimeUnit="FullDuration" RoomPricingType="Per stay" UnitMultiplier="1">
+                  <PaymentPolicies>
+                    <GuaranteePayment>
+                      <AcceptedPayments>
+                        <AcceptedPayment>
+                          <PaymentCard>
+                            <CardType>VISA</CardType>
+                          </PaymentCard>
+                        </AcceptedPayment>
+                      </AcceptedPayments>
+                    </GuaranteePayment>
+                    <GuaranteePayment>
+                      <AcceptedPayments>
+                        <AcceptedPayment>
+                          <PaymentCard>
+                            <CardType>Mastercard</CardType>
+                          </PaymentCard>
+                        </AcceptedPayment>
+                      </AcceptedPayments>
+                    </GuaranteePayment>
+                  </PaymentPolicies>
+                  <Total AmountAfterTax="149.00" AmountBeforeTax="141.23" CurrencyCode="EUR" DecimalPlaces="2"/>
+                  <RateDescription>
+                    <Text>Hot Deal</Text>
+                    <Text>Gratuit pour les clients HRS: Quotidien gratuit, Parking attenant à l'hôtel</Text>
+                  </RateDescription>
+                </Rate>
+              </Rates>
+            </RoomRate>
+          </RoomRates>
+          <GuestCounts>
+            <GuestCount Count="1"/>
+          </GuestCounts>
+          <TimeSpan End="2019-05-23" Start="2019-05-22"/>
+          <BasicPropertyInfo HotelCode="36151" HotelName="Château de la Pioline">
+            <Address>
+              <AddressLine>260 Rue Guillaume du Vair</AddressLine>
+              <CityName>AIX EN PROVENCE</CityName>
+              <PostalCode>13546</PostalCode>
+              <CountryName Code="FR">French Republic France</CountryName>
+            </Address>
+            <ContactNumbers>
+              <ContactNumber PhoneNumber="33442522727"/>
+            </ContactNumbers>
+          </BasicPropertyInfo>
+        </RoomStay>
+        <RoomStay>
+          ... and another RoomStay nodes follow here for all the returned rooms for all the hotels (properties) per Availability request 
+        </RoomStay>
+      </RoomStays>
+    </OTA_HotelAvailRS>
+  </soap:Body>
+</soap:Envelope>
 ```
 
+
 ### Search results displayed
+
+Search results page displaying hotels, based on Search response, and their rates, based on Availability response:
 
 ![./media/image1.png](./images/examples/search_results.png)
 
 
-
-
-
-
-
-
-
-
-# Availability
-
-Click the 'View Rooms' button on any search result will trigger a single-property request
-
-### Request
-```xml
-
-```
-
-### Response
-```xml
-
-```
-
-
-### Availability results displayed
+WIth Availability response also cancellation information comes which can be displayed in separate popup:
 
 ![./media/image1.png](./images/examples/17.png)
 

--- a/src/api-reference/direct-connects/hotel-service-2/Availability.markdown
+++ b/src/api-reference/direct-connects/hotel-service-2/Availability.markdown
@@ -3,8 +3,6 @@ title: Direct Connect - Hotel v2 - Availability
 layout: reference
 ---
 
-{% include prerelease.html %}
-
 Message to retrieved the availability of hotels
 
 | SOAPAction   | OTA name   | Message structure |

--- a/src/api-reference/direct-connects/hotel-service-2/Availability.markdown
+++ b/src/api-reference/direct-connects/hotel-service-2/Availability.markdown
@@ -144,20 +144,21 @@ Message to retrieved the availability of hotels
 
 | Element     | Required | Data Type | Description |
 |-------------|----------|-----------|-------------|
-| GuestCounts | Y        | Complex   | **Please note: this field is currently being discussed with our partners as the plan to remove GuestCounts from OTA_HotelAvailRQ**. A collection of Guest Counts associated with Room Stay. |
+| GuestCounts | Y        | Complex   | A collection of Guest Counts associated with Room Stay. |
 
 #### GuestCounts
 
 | Element    | Required | Data Type | Description |
 |------------|----------|-----------|-------------|
-| GuestCount | Y        | Complex   | **Please note: this element is planned to be removed** A recurring element that identifies the number of guests and ages of the guests. |
+| GuestCount | Y        | Complex   | A recurring element that identifies the number of guests and ages of the guests. It currently contains hardcoded values only - see Guest Count below. |
 
 #### GuestCount
 
 | Element             | Required | Data Type | Description |
 |---------------------|----------|-----------|-------------|
-| *Count*             | Y        | Int	     | SAP Concur only supports one Guest thus the value is currently hard-coded to '1'. |
-| *AgeQualifyingCode* | Y        | Int       | The value is currently hard-coded to '10': AgeQualifyingCode="10" |
+| Count               | Y        | Int	     | SAP Concur only supports one Guest thus the value is currently hard-coded to '1'. |
+| AgeQualifyingCode   | Y        | Int       | The value is currently hard-coded to '10': AgeQualifyingCode="10" |
+
 ---
 
 ## <a name="response"></a>Response

--- a/src/api-reference/direct-connects/hotel-service-2/FAQ.markdown
+++ b/src/api-reference/direct-connects/hotel-service-2/FAQ.markdown
@@ -1,6 +1,0 @@
----
-title: Direct Connect - Hotel v2 - FAQ
-layout: reference
----
-
-# Hotel Service 2 Frequently Asked Questions

--- a/src/api-reference/direct-connects/hotel-service-2/Headers.markdown
+++ b/src/api-reference/direct-connects/hotel-service-2/Headers.markdown
@@ -3,8 +3,6 @@ title: Direct Connect - Hotel v2 - Headers
 layout: reference
 ---
 
-{% include prerelease.html %}
-
 SAP Concur will send the user-name and password in both the HTTP header and the SOAP header.  IF the user-name and password generates an authentication error, then SAP Concur expects an HTTP 403 response.
 
 * [HTTP Headers](#http)

--- a/src/api-reference/direct-connects/hotel-service-2/Headers.markdown
+++ b/src/api-reference/direct-connects/hotel-service-2/Headers.markdown
@@ -89,7 +89,6 @@ Every message must contain the following required attributes and elements.  On t
 | Element         | Required | Data Type          | Description |
 |-----------------|----------|--------------------|-------------|
 | *EchoToken*     | Y        | StringLength1to128 | A reference for additional message identification, assigned by the requesting host system. |
-| *Timestamp*     | Y        | DateTimeType       | Timestmap of XYZ operation - **To be confirmed what this actually means** |
 | *Version*       | Y        | Double            | The OpenTravel message version indicated by a decimal value. |
 | *PrimaryLangID* | Y        | String             | The primary language preference for the message encoded as ISO 639-1 |
 | *AltLangID*     | Y        | String             | The alternate language for a customer or message encoded as ISO 639-1. |

--- a/src/api-reference/direct-connects/hotel-service-2/Introduction.markdown
+++ b/src/api-reference/direct-connects/hotel-service-2/Introduction.markdown
@@ -59,11 +59,6 @@ As sensitive data and payment card details are transferred via API, the Hotel Su
 #### HTTPS
 SAP Concur prefers to use the newer TLS 1.2, however TLS 1.1 is still supported. TLS 1.0 is **not** supported. The Hotel Supplier will provide SAP Concur HTTPS URL of its end-point. Standard HTTPS port 443 should be used.
 
-#### Concur IP Ranges
-
-*Check with SM to see if we already have a publicly available list of IPs suppliers/vendors have to white-list.*
-
-
 ## <a name="urls"></a>URLs
 SAP Concur will receive a single URL from the Hotel Supplier. All requests will go to that URL.
 

--- a/src/api-reference/direct-connects/hotel-service-2/Introduction.markdown
+++ b/src/api-reference/direct-connects/hotel-service-2/Introduction.markdown
@@ -3,8 +3,6 @@ title: Direct Connect - Hotel v2 - Introduction
 layout: reference
 ---
 
-{% include prerelease.html %}
-
 ## <a name="overview"></a>Overview
 The Hotel Services v2 Direct Connect from Concur Connect provides a method for Travel users to access hotel inventory.
 

--- a/src/api-reference/direct-connects/hotel-service-2/Use-cases.markdown
+++ b/src/api-reference/direct-connects/hotel-service-2/Use-cases.markdown
@@ -3,8 +3,6 @@ title: Direct Connect - Hotel v2 - Use Cases
 layout: reference
 ---
 
-{% include prerelease.html %}
-
 Basic scenario encompassing all the functionality provided by Hotel Service 2 incorporated into Concur Travel starting from a hotel search, through to confirmation of a booking and ending with a cancellation.
 
 * [Actors](#actors)


### PR DESCRIPTION
Removing prerelease.html from all HS2 pages on PM request as development has been finished some time ago with first partners being live and other migrating / waiting for onboarding.