### PR TITLE
PIE-2028/Removed currency field from payment object

### DIFF
--- a/src/api-explorer/v4-0/InvoicePay.swagger2.json
+++ b/src/api-explorer/v4-0/InvoicePay.swagger2.json
@@ -147,9 +147,6 @@
     "payment": {
       "type": "object",
       "properties": {
-        "currency": {
-          "type": "string"
-        },
         "invoices": {
           "type": "array",
           "items": {


### PR DESCRIPTION
Removed currency field from payment object in IPM payment response.