### PR TITLE
 Modify to accept employee ID in lieu of email for an employee

### DIFF
--- a/src/api-reference/budget/v4.budget-header.md
+++ b/src/api-reference/budget/v4.budget-header.md
@@ -159,7 +159,8 @@ concur-correlationid: dd6cee88-b725-4c06-9ee9-0ca4ae4f16b2
           "employeeUuid":"210fe25f-e326-495c-847a-de333173f616",
           "id":"f779261d-77ce-4123-b739-d842ef6f104d",
           "name":"Jean Normandy",
-    	  "email":"jean.normandy@xyz.com"
+    	  "email":"jean.normandy@xyz.com",
+          "employeeId":"jean.normandy"
          },
         "budgetApprovers":[
 	      {
@@ -167,7 +168,8 @@ concur-correlationid: dd6cee88-b725-4c06-9ee9-0ca4ae4f16b2
             "employeeUuid":"210fe25f-e326-495c-847a-de333173f616",
             "id":"f779261d-77ce-4123-b739-d842ef6f104d",
             "name":"Jean Normandy",
-        	"email":"jean.normandy@xyz.com"
+        	"email":"jean.normandy@xyz.com",
+            "employeeId":"jean.normandy"
           }
         ],
         "budgetManagers":[
@@ -176,7 +178,8 @@ concur-correlationid: dd6cee88-b725-4c06-9ee9-0ca4ae4f16b2
             "employeeUuid":"13a13839-68d6-4ee8-90e9-58604278aa8f",
             "id":"e2bae688-e000-464a-8728-e1362c94f172",
             "name":"Walter Gupta",
-        	"email":"walter.gupta@xyz.com"
+        	"email":"walter.gupta@xyz.com",
+            "employeeId":"walter.gupta"
           }
         ],
         "budgetViewers":[
@@ -185,7 +188,8 @@ concur-correlationid: dd6cee88-b725-4c06-9ee9-0ca4ae4f16b2
             "employeeUuid":"eb6082b0-3a9a-4e79-a350-e6e067f34969",
             "id":"7ce7dfe0-6168-4b93-bb35-386bf023acc6",
             "name":"Dan Lee",
-	        "email":"dan.lee@xyz.com"
+	        "email":"dan.lee@xyz.com",
+            "employeeId":"dan.lee"
           }
         ],
         "fiscalYear":{
@@ -318,7 +322,9 @@ concur-correlationid: 918cfb55-06a1-47da-8ef1-774a45427af9
       "externalUserCUUID":"8002250890004822936",
       "employeeUuid":"210fe25f-e326-495c-847a-de333173f616",
       "id":"f779261d-77ce-4123-b739-d842ef6f104d",
-      "name":"Jean Normandy"
+      "name":"Jean Normandy",
+      "email":"jean.normandy@xyz.com",
+      "employeeId":"jean.normandy"
      },
     "budgetApprovers":[
        {
@@ -326,7 +332,8 @@ concur-correlationid: 918cfb55-06a1-47da-8ef1-774a45427af9
         "employeeUuid":"210fe25f-e326-495c-847a-de333173f616",
         "id":"f779261d-77ce-4123-b739-d842ef6f104d",
         "name":"Jean Normandy",
-        "email":"jean.normandy@xyz.com"
+        "email":"jean.normandy@xyz.com",
+        "employeeId":"jean.normandy"
        }
     ],
     "budgetManagers":[
@@ -335,7 +342,8 @@ concur-correlationid: 918cfb55-06a1-47da-8ef1-774a45427af9
         "employeeUuid":"13a13839-68d6-4ee8-90e9-58604278aa8f",
         "id":"e2bae688-e000-464a-8728-e1362c94f172",
         "name":"Walter Gupta",
-        "email":"walter.gupta@xyz.com"
+        "email":"walter.gupta@xyz.com",
+        "employeeId":"walter.gupta"
       }
     ],
     "budgetViewers":[
@@ -344,7 +352,8 @@ concur-correlationid: 918cfb55-06a1-47da-8ef1-774a45427af9
         "employeeUuid":"eb6082b0-3a9a-4e79-a350-e6e067f34969",
         "id":"7ce7dfe0-6168-4b93-bb35-386bf023acc6",
         "name":"Dan Lee",
-	"email":"dan.lee@xyz.com"
+	    "email":"dan.lee@xyz.com",
+        "employeeId":"dan.lee"
       }
     ],
     "budgetItemDetails":[
@@ -520,27 +529,31 @@ Authorization: Bearer {token}
     "owner":{
       "externalUserCUUID":"8002250890004822936",
       "employeeUuid":"210fe25f-e326-495c-847a-de333173f616",
-      "email":"jean.normandy@xyz.com"
+      "email":"jean.normandy@xyz.com",
+      "employeeId":"jean.normandy"
      },
     "budgetApprovers":[
       {
         "externalUserCUUID":"5005380230004873464",
         "employeeUuid":"eb6082b0-3a9a-4e79-a350-e6e067f34969",
-	    "email":"dan.lee@xyz.com"
+	    "email":"dan.lee@xyz.com",
+        "employeeId":"dan.lee"
       }
     ],
     "budgetManagers":[
       {
         "externalUserCUUID":"1563846384638464842",
         "employeeUuid":"13a13839-68d6-4ee8-90e9-58604278aa8f",
-        "email":"walter.gupta@xyz.com"
+        "email":"walter.gupta@xyz.com",
+        "employeeId":"walter.gupta"
       }
     ],
     "budgetViewers":[
       {
         "externalUserCUUID":"5005380230004873464",
         "employeeUuid":"eb6082b0-3a9a-4e79-a350-e6e067f34969",
-        "email":"dan.lee@xyz.com"
+        "email":"dan.lee@xyz.com",
+        "employeeId":"dan.lee"
       }
     ],
     "budgetItemDetails":[
@@ -798,7 +811,7 @@ Name|Type|Format|Description
 
 ### <a name="budgetPerson"></a>BudgetPerson
 
-Provide externalUserCUUID or email of the user for looking up the person.
+Provide externalUserCUUID or email or employee ID of the user for looking up the person.
 
 Name|Type|Format|Description
 ---|---|---|---
@@ -806,6 +819,7 @@ Name|Type|Format|Description
 `name`|`string`|-|The user's name.  Provided for convenience.  **READ ONLY**
 `id`|`string`|-|The budget service's key for this object.
 `email`|`string`|-|The email address of the person to lookup.
+`employeeId`|`string`|-|The employee ID of the person to lookup.
 
 
 ### <a name="budgetCategory"></a>BudgetCategory

--- a/src/api-reference/budget/v4.budget-header.md
+++ b/src/api-reference/budget/v4.budget-header.md
@@ -159,7 +159,7 @@ concur-correlationid: dd6cee88-b725-4c06-9ee9-0ca4ae4f16b2
           "employeeUuid":"210fe25f-e326-495c-847a-de333173f616",
           "id":"f779261d-77ce-4123-b739-d842ef6f104d",
           "name":"Jean Normandy",
-    	  "email":"jean.normandy@xyz.com",
+          "email":"jean.normandy@xyz.com",
           "employeeId":"jean.normandy"
          },
         "budgetApprovers":[
@@ -168,7 +168,7 @@ concur-correlationid: dd6cee88-b725-4c06-9ee9-0ca4ae4f16b2
             "employeeUuid":"210fe25f-e326-495c-847a-de333173f616",
             "id":"f779261d-77ce-4123-b739-d842ef6f104d",
             "name":"Jean Normandy",
-        	"email":"jean.normandy@xyz.com",
+            "email":"jean.normandy@xyz.com",
             "employeeId":"jean.normandy"
           }
         ],
@@ -178,7 +178,7 @@ concur-correlationid: dd6cee88-b725-4c06-9ee9-0ca4ae4f16b2
             "employeeUuid":"13a13839-68d6-4ee8-90e9-58604278aa8f",
             "id":"e2bae688-e000-464a-8728-e1362c94f172",
             "name":"Walter Gupta",
-        	"email":"walter.gupta@xyz.com",
+            "email":"walter.gupta@xyz.com",
             "employeeId":"walter.gupta"
           }
         ],
@@ -188,7 +188,7 @@ concur-correlationid: dd6cee88-b725-4c06-9ee9-0ca4ae4f16b2
             "employeeUuid":"eb6082b0-3a9a-4e79-a350-e6e067f34969",
             "id":"7ce7dfe0-6168-4b93-bb35-386bf023acc6",
             "name":"Dan Lee",
-	        "email":"dan.lee@xyz.com",
+            "email":"dan.lee@xyz.com",
             "employeeId":"dan.lee"
           }
         ],
@@ -352,7 +352,7 @@ concur-correlationid: 918cfb55-06a1-47da-8ef1-774a45427af9
         "employeeUuid":"eb6082b0-3a9a-4e79-a350-e6e067f34969",
         "id":"7ce7dfe0-6168-4b93-bb35-386bf023acc6",
         "name":"Dan Lee",
-	    "email":"dan.lee@xyz.com",
+        "email":"dan.lee@xyz.com",
         "employeeId":"dan.lee"
       }
     ],
@@ -536,7 +536,7 @@ Authorization: Bearer {token}
       {
         "externalUserCUUID":"5005380230004873464",
         "employeeUuid":"eb6082b0-3a9a-4e79-a350-e6e067f34969",
-	    "email":"dan.lee@xyz.com",
+        "email":"dan.lee@xyz.com",
         "employeeId":"dan.lee"
       }
     ],


### PR DESCRIPTION
Budget endpoints should accept employee ID in place of email ID/employee CUUID to identify an employee.