### PR TITLE
Updating to SAP Concur branding

### DIFF
--- a/src/manage-apps/go-market-docs/app-center-ux-guidelines-consumer.markdown
+++ b/src/manage-apps/go-market-docs/app-center-ux-guidelines-consumer.markdown
@@ -131,11 +131,11 @@ This section provides a summarized checklist of the required and recommended com
   * Must provide back/forward navigation, where applicable. (required)
   * Should be [Section 508 Compliance](https://www.section508.gov) (strongly recommended)
   * Should include support and help options clearly throughout the process.
-  * Must support major browsers and versions. The full list of Concur-supported browsers is available [here](https://www.concurtraining.com/customers/tech_pubs/Docs/Z_SuppConfig/Supported_Configurations_for_Concur_Travel_and_Expense_Client-Facing.pdf). (required)
+  * Must support major browsers and versions. The full list of SAP Concur-supported browsers is available [here](https://www.concurtraining.com/customers/tech_pubs/Docs/Z_SuppConfig/Supported_Configurations_for_Concur_Travel_and_Expense_Client-Facing.pdf). (required)
   * Should adhere to your company’s brand and marketing guidelines
   * Must include your company branding and specific application brand, if applicable (required)
 * On the first page (at a minimum),
-  * Must clearly indicate this is an integration with Concur (required)
+  * Must clearly indicate this is an integration with SAP Concur (required)
   * Must include links to your terms and conditions and privacy policy (required)
 
 


### PR DESCRIPTION
Updating to say "SAP Concur" to help partners correctly brand their landing pages.

