### PR TITLE
EXP-29565: Remove the Cost Object query string parameter from the API documentation

### DIFF
--- a/src/api-explorer/v3-0/Reports.swagger2.json
+++ b/src/api-explorer/v3-0/Reports.swagger2.json
@@ -175,13 +175,6 @@
             "type": "string"
           },
           {
-            "name": "costObject",
-            "in": "query",
-            "description": "The list item code for an allocation field for at least allocation in the report.",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name": "entryTransactionDateBefore",
             "in": "query",
             "description": "The entry transaction date for at least one expense entry in the report is before this date.Format: YYYY-MM-DD",

--- a/src/api-reference/expense/expense-report/v3.reports.markdown
+++ b/src/api-reference/expense/expense-report/v3.reports.markdown
@@ -46,7 +46,6 @@ Name|Type|Format|Description
 `hasBillableExpenses`|`Boolean`|`query`|The IsBillable flag for at least one expense entry in the report. Format: true or false.
 `isTestUser`|`Boolean`|`query`|The report owner is a test user using the report for testing purposes in a non-production environment. Format: true or false.
 `expenseGroupConfigID`|`string`|`query`|The unique identifier for the expense group configuration associated to the report's expense group. Use the ID from the Response of the Expense Group Configurations V3.
-`costObject`|`string`|`query`|The list item code for an allocation field for at least allocation in the report.
 `entryTransactionDateBefore`|`DateTime`|`query`|The entry transaction date for at least one expense entry in the report is before this date. Format: YYYY-MM-DD
 `entryTransactionDateAfter`|`DateTime`|`query`|The entry transaction date for at least one expense entry in the report is after this date. Format: YYYY-MM-DD
 `createDateBefore`|`DateTime`|`query`|The report create date is before this date. Format: YYYY-MM-DD


### PR DESCRIPTION

* Removed cost object query string from the API reference section of the developer.concur.com site

* Removed cost object query string from the API explorer section of the developer.concur.com site