### PR TITLE
Add the receipts scope

### DIFF
--- a/src/api-reference/expense/quick-expense/v4.quick-expense.md
+++ b/src/api-reference/expense/quick-expense/v4.quick-expense.md
@@ -161,6 +161,7 @@ Creates a quick expense with an image.
 ### Scopes
 
 `quickexpense.writeonly` - Refer to [Scope Usage](#scope-usage) for full details.
+`receipts.writeonly` - If the client has e-Bunsho activated, it required.
 
 ### Request
 


### PR DESCRIPTION
receipts.writeonly scope is needed only for e-bunsho images that are posted with quick expenses.
https://jira.concur.com/browse/CRMC-139571

