### PR TITLE
expenseTypeId is required in payload.

### DIFF
--- a/src/api-reference/expense/quick-expense/v4.quick-expense.md
+++ b/src/api-reference/expense/quick-expense/v4.quick-expense.md
@@ -261,7 +261,7 @@ Name|Type|Format|Description
 ---|---|---|---
 `comment`|`string`|-|This is a comment attached to the quick expense.
 `entryDetails`|`string`|-|The quick expense entry details.
-`expenseTypeId`|`string`|-|This is the expense type id of quick expense. Use [Expense Group Configurations v3.0](/api-reference/expense/expense-report/expense-group-configurations.html) to retrieve the supported expense types.
+`expenseTypeId`|`string`|-|**Required** This is the expense type id of quick expense. Use [Expense Group Configurations v3.0](/api-reference/expense/expense-report/expense-group-configurations.html) to retrieve the supported expense types.
 `location`|-|[Location](#location-schema)|The location where the quick expense occurred.
 `paymentTypeId`|`string`|-|This is the payment type id of quick expense. Supported values: `CASHX`, `CPAID`, `PENDC`.
 `transactionAmount`|-|[Amount](#amount-schema)|**Required** The amount of the quick expense.


### PR DESCRIPTION
When I post Quick Expense v4 data, I got following message. It looks ExpenseTypeId is required.

    "httpStatus": "400 - Bad Request",
    "errorMessage": "Request received without ExpenseTypeId",

