### PR TITLE
Update post-list-search-request.markdown

### DIFF
--- a/src/api-reference/callouts/post-list-search-request.markdown
+++ b/src/api-reference/callouts/post-list-search-request.markdown
@@ -39,6 +39,10 @@ The request will contain a **fetch-list-request** parent element, containing the
 |  search-by |  Indicates which list item attribute should be searched. Possible values are TEXT or CODE.<br/>**NOTE**: The application connector must support both attributes in order to properly handle wildcard searches. |
 |  lang-code |  The two character code for the language of the user. |
 |  num-to-return |  Expense will specify the number of items to return. The application connector must use this value to ensure that it does not return more results than requested. There is a system limit of 1000 items. |
+|  protected-list-key  |     |
+|  list-name  |     |
+|  connector-version  |     |
+|  config-options  |      |
 |  code-by-level |  Indicates the code at each level in the case of a multi-level list. |
 
 ####  <a name="req-examples"></a>XML Example Request for Single Level List
@@ -59,7 +63,11 @@ Content-Length: {length of content body}
     <query>Alph*</query>
     <search-by>TEXT</search-by>
     <lang-code>EN</lang-code>
-    <num-to-return>500</num-to-return>		
+    <num-to-return>500</num-to-return>
+    <protected-list-key />
+    <list-name />
+    <connector-version />
+    <config-options />
 </fetch-list-request>
 ```
 
@@ -82,12 +90,16 @@ Content-Length: {length of content body}
     <search-by>TEXT</search-by>
     <lang-code>EN</lang-code>
     <num-to-return>500</num-to-return>
+    <protected-list-key />
+    <list-name />
+    <connector-version />
+    <config-options />
     <code-by-level>
         <level1>US</level1>
         <level2>W</level2>
         <level3>CA</level3>      
     </code-by-level>
-</fetch-list-request>
+ </fetch-list-request>
 ```
 
 ## <a name="response"></a>Response
@@ -104,10 +116,10 @@ The response will include a **fetch-list-response** parent element, with an **it
 
 |  Element |  Description |
 |---------------|--------------|
-| code |  The long code for the list item, consisting of the long code from the request combined with the short code from the response, separated by a hyphen (-). |
-| short-code |  The short code for the list item. |
-| text |  The list item text. |
-| match-value |  The value that matched the search term. |
+| code |  The long code for the list item, consisting of the long code from the request combined with the short code from the response, separated by a hyphen (-). (REQUIRED)|
+| short-code |  The short code for the list item. (REQUIRED)|
+| text |  The list item text. (REQUIRED)|
+| match-value |  The value that matched the search term. (REQUIRED)|
 
 ####  <a name="res-examples"></a>XML Example of Response with Results
 


### PR DESCRIPTION
The  fields that were added as part of this Documentation update, are being sent to the designated Client Endpoint from the Concur Callout Server. Currently they are not documented and this has caused confusion to the customers Implementing this Callout. An example is the  CRMC-126622 created for Siemens. The proposed changed will mitigate the gap between documentation and what is being sent to the Customers as part of the XML.
The fields description is not known to me  and this is the reason that an empty space has been used in this part of the Documentation. 

The second change is regarding the Required Fields of the Response that is being sent as part of the Callout and they should be marked as Required. The reason is that the lack of marking them in the documentation creates the impression to the customers that they can skip sending them back which will cause failure to the Callout functionality. This has created problems in Callout Client Implementation Projects like Siemens, Generalli and others in the past, by following the existing Documentation.

