### PR TITLE
Please update supported image types

### DIFF
--- a/src/api-reference/expense/quick-expense/v4.quick-expense.md
+++ b/src/api-reference/expense/quick-expense/v4.quick-expense.md
@@ -180,7 +180,7 @@ Name|Type|Format|Description
 ---|---|---|---
 `userID`|`string`|-|**Required** The unique identifier of the SAP Concur user. Use [User Profile v1.0](/api-reference/profile/v1.user.html) to retrieve the `userID`.
 `contextType`|`string`|-|**Required** The access level of the SAP Concur user, which determines the form fields they can view/modify. Supported values: TRAVELER.
-`fileContent`|`file`|-|**Required** The quick expense image. Maximum size 5 MBs. Supported image types are: PNG, GIF, PDF, TIFF, JPEG
+`fileContent`|`file`|-|**Required** The quick expense image. Maximum size 5 MBs. Supported image types are: PNG, PDF, TIFF, JPEG
 
 #### Headers
 


### PR DESCRIPTION
>`fileContent`|`file`|-|**Required** The quick expense image. Maximum size 5 MBs. Supported image types are: PNG, PDF, TIFF, JPEG

GIF file is not supported in UI. (PNG, JPG, JPEG, PDF, TIF, TIFF file for upload are valid.) So, description should be same as Receipt Upload in UI.

