### PR TITLE
Reverting code fix - was an admin panel issue

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -1,5 +1,5 @@
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<!--<script async src="https://www.googletagmanager.com/gtag/js?id=UA-148078744-1"></script>-->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-148078744-1"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag() { dataLayer.push(arguments); }


### PR DESCRIPTION
Reverting the code fix because the problem was actually in the admin panel in google tag manager. Google Analytics by default records page views and Google Tag Manager was mistakenly setup to record page views as well.

