### PR TITLE
Fixed broken response 200 objects that had semantic errors in them ca…

### DIFF
--- a/swagger/draft/api-list-v4.json
+++ b/swagger/draft/api-list-v4.json
@@ -82,7 +82,7 @@
           "200": {
             "description": "Successfully got all lists of list category",
             "schema": {
-              "$ref": "#/definitions/PagedResources«ListResponse»"
+              "$ref": "#/definitions/PagedResourcesListResponse"
             }
           },
           "400": {
@@ -112,8 +112,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -175,7 +174,7 @@
           "200": {
             "description": "Successfully get all lists",
             "schema": {
-              "$ref": "#/definitions/PagedResources«ListResponse»"
+              "$ref": "#/definitions/PagedResourcesListResponse"
             }
           },
           "400": {
@@ -199,8 +198,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -290,8 +288,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -381,8 +378,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -494,8 +490,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -572,8 +567,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -849,7 +843,7 @@
       },
       "title": "PageMetadata"
     },
-    "PagedResources«ListResponse»": {
+    "PagedResourcesListResponse": {
       "type": "object",
       "properties": {
         "content": {
@@ -874,7 +868,7 @@
           "$ref": "#/definitions/PageMetadata"
         }
       },
-      "title": "PagedResources«ListResponse»"
+      "title": "PagedResourcesListResponse"
     },
     "ValidationError": {
       "type": "object",

--- a/swagger/draft/api-listcategory-v4.json
+++ b/swagger/draft/api-listcategory-v4.json
@@ -81,7 +81,7 @@
           "200": {
             "description": "Successfully get all categories",
             "schema": {
-              "$ref": "#/definitions/PagedResources«CategoryResponse»"
+              "$ref": "#/definitions/PagedResourcesCategoryResponse"
             }
           },
           "400": {
@@ -111,8 +111,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -202,8 +201,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -293,8 +291,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -406,8 +403,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -484,8 +480,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -697,7 +692,7 @@
       },
       "title": "PageMetadata"
     },
-    "PagedResources«CategoryResponse»": {
+    "PagedResourcesCategoryResponse": {
       "type": "object",
       "properties": {
         "content": {
@@ -722,7 +717,7 @@
           "$ref": "#/definitions/PageMetadata"
         }
       },
-      "title": "PagedResources«CategoryResponse»",
+      "title": "PagedResourcesCategoryResponse",
       "xml": {
         "name": "pagedEntities",
         "attribute": false,

--- a/swagger/draft/api-listitem-v4.json
+++ b/swagger/draft/api-listitem-v4.json
@@ -133,8 +133,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -238,8 +237,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -329,8 +327,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -442,8 +439,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -520,8 +516,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -663,7 +658,7 @@
           "200": {
             "description": "Successfully got children of list item",
             "schema": {
-              "$ref": "#/definitions/PagedResources«ListItem»"
+              "$ref": "#/definitions/PagedResourcesListItem"
             }
           },
           "400": {
@@ -693,8 +688,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -787,8 +781,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -930,7 +923,7 @@
           "200": {
             "description": "Successfully got first level list items of list",
             "schema": {
-              "$ref": "#/definitions/PagedResources«ListItem»"
+              "$ref": "#/definitions/PagedResourcesListItem"
             }
           },
           "400": {
@@ -960,8 +953,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -1058,8 +1050,7 @@
         },
         "security": [
           {
-            "JWT Token": [
-            ]
+            "JWT Token": []
           }
         ],
         "deprecated": false
@@ -1335,7 +1326,7 @@
       },
       "title": "PageMetadata"
     },
-    "PagedResources«ListItem»": {
+    "PagedResourcesListItem": {
       "type": "object",
       "properties": {
         "content": {
@@ -1360,7 +1351,7 @@
           "$ref": "#/definitions/PageMetadata"
         }
       },
-      "title": "PagedResources«ListItem»"
+      "title": "PagedResourcesListItem"
     },
     "ValidationError": {
       "type": "object",


### PR DESCRIPTION
…used by illegal characters.

Fixed broken response 200 objects that had semantic errors in them caused by illegal characters. Changes shown below:

PagedResources«ListResponse» -> PagedResourcesListResponse

PagedResources«CategoryResponse» -> PagedResourcesCategoryResponse

PagedResources«ListItem» -> PagedResourcesListItem

Also cleaned up the JWT Token objects.

