### PR TITLE
Not able to get reportKEY by using Reports API v3.

### DIFF
--- a/src/api-reference/expense/expense-report/post-report-submission.markdown
+++ b/src/api-reference/expense/expense-report/post-report-submission.markdown
@@ -87,7 +87,7 @@ X-UserID: cmiller@example.com
 ```
 
 [1]: /api-reference/expense/expense-report/expense-delegators.html#get
-[2]: /api-reference/expense/expense-report/v3.reports.html#get
-[3]: /api-reference/expense/expense-report/v3.reports.html#getID
-[4]: /api-reference/expense/expense-report/v3.reports.html#post
+[2]: /api-reference/expense/expense-report/v1dot1.reports-list.html#get
+[3]: /api-reference/expense/expense-report/v1dot1.reports.html#getID
+[4]: /api-reference/expense/expense-report/v1dot1.reports.html#post
 [6]: https://developer.concur.com/reference/http-codes


### PR DESCRIPTION
To get the report key Developer would still need to use the v1.1 report list
API: https://www.concursolutions.com/api/expense/expensereport/v1.1/reportslist
Reference: https://developer.concur.com/api-reference/expense/expense-report/v1dot1.reports-list.html

**URI Source**: The reportId value is returned by the [Get List of Reports][2] and [Get Report Details][3] functions, and as part of the **Report-Details-Url** element of the [Post Expense Report Header][4] function.

URL should be as below.

[2]: /api-reference/expense/expense-report/v1dot1.reports-list.html#get
[3]: /api-reference/expense/expense-report/v1dot1.reports.html#getID
[4]: /api-reference/expense/expense-report/v1dot1.reports.html#post

