### PR TITLE
Remove Usage Metric Endpoints from Budget

### DIFF
--- a/src/api-explorer/v4-0/Budget.swagger2.json
+++ b/src/api-explorer/v4-0/Budget.swagger2.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "description": "The Budget service exposes budget and fiscal year data. Partners may use the service endpoints to read and alter fiscal year, budget, budget adjustment, and budget matching configuration. Summary and detailed balance amounts are also available to read, but may not be altered via the API.",
+    "description": "The Budget service exposes budget and fiscal year data. Partners and clients may use the service endpoints to read and alter fiscal year, budget, budget adjustment, and budget matching configuration. Summary and detailed balance amounts are also available to read, but may not be altered via the API.",
     "version": "4.0.0",
     "title": "Budget Service API Documentation"
   },
@@ -27,10 +27,6 @@
     {
       "name": "Fiscal Year",
       "description": "Fiscal Year"
-    },
-    {
-      "name": "Usage Metrics",
-      "description": "Save and get usage metrics for a given user"
     }
   ],
   "paths": {
@@ -332,7 +328,7 @@
         "tags": [
           "Budget Item"
         ],
-        "summary": "Fetch all budget items for an entity. Defaults adminView to false and offset to zero.",
+        "summary": "Fetch all budget items for an entity.",
         "operationId": "searchBudgetItemsPagedUsingGET",
         "produces": [
           "application/json"
@@ -341,16 +337,19 @@
           {
             "name": "adminView",
             "in": "query",
-            "description": "adminView",
+            "description": "Response is needed for administration purpose",
             "required": false,
-            "type": "string"
+            "type": "boolean",
+            "default": false,
+            "x-example": false
           },
           {
             "name": "offset",
             "in": "query",
-            "description": "offset",
+            "description": "Offset based pagination",
             "required": false,
             "type": "integer",
+            "default": 0,
             "format": "int32"
           }
         ],
@@ -426,59 +425,6 @@
           },
           "500": {
             "description": "Internal error"
-          }
-        },
-        "deprecated": false
-      }
-    },
-    "/budget/v4/budgetItemHeader/export": {
-      "get": {
-        "tags": [
-          "Budget Item"
-        ],
-        "summary": "exportByFilter",
-        "operationId": "exportByFilterUsingGET",
-        "produces": [
-          "text/html"
-        ],
-        "parameters": [
-          {
-            "name": "entityId",
-            "in": "query",
-            "description": "entityId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "fyId",
-            "in": "query",
-            "description": "fyId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "query",
-            "in": "query",
-            "description": "query",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "string"
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "404": {
-            "description": "Not Found"
           }
         },
         "deprecated": false
@@ -862,207 +808,6 @@
         },
         "deprecated": false
       }
-    },
-    "/budget/v4/metrics": {
-      "post": {
-        "tags": [
-          "Usage Metrics"
-        ],
-        "summary": "Save a metric",
-        "operationId": "saveInteractionUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "metricType",
-            "in": "query",
-            "description": "metricType",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "string"
-            }
-          },
-          "201": {
-            "description": "Created"
-          },
-          "400": {
-            "description": "Invalid request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "404": {
-            "description": "Not Found"
-          },
-          "500": {
-            "description": "Internal error"
-          }
-        },
-        "deprecated": false
-      }
-    },
-    "/budget/v4/metrics/aggregate": {
-      "post": {
-        "tags": [
-          "Usage Metrics"
-        ],
-        "summary": "Aggregate all metrics within given dates",
-        "operationId": "aggregateUsingPOST",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "fromDate",
-            "in": "query",
-            "description": "fromDate",
-            "required": true,
-            "type": "string",
-            "format": "date-time"
-          },
-          {
-            "name": "toDate",
-            "in": "query",
-            "description": "toDate",
-            "required": true,
-            "type": "string",
-            "format": "date-time"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "string"
-            }
-          },
-          "201": {
-            "description": "Created"
-          },
-          "400": {
-            "description": "Invalid request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "404": {
-            "description": "Not Found"
-          },
-          "500": {
-            "description": "Internal error"
-          }
-        },
-        "deprecated": false
-      }
-    },
-    "/budget/v4/metrics/entity": {
-      "get": {
-        "tags": [
-          "Usage Metrics"
-        ],
-        "summary": "Get metrics for an entity",
-        "operationId": "getEntityInteractionsUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "entityId",
-            "in": "query",
-            "description": "entityId",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "string"
-            }
-          },
-          "400": {
-            "description": "Invalid request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "404": {
-            "description": "Not Found"
-          },
-          "500": {
-            "description": "Internal error"
-          }
-        },
-        "deprecated": false
-      }
-    },
-    "/budget/v4/metrics/user": {
-      "get": {
-        "tags": [
-          "Usage Metrics"
-        ],
-        "summary": "Get metrics for a user",
-        "operationId": "getInteractionsUsingGET",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "userUuid",
-            "in": "query",
-            "description": "userUuid",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "string"
-            }
-          },
-          "400": {
-            "description": "Invalid request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "404": {
-            "description": "Not Found"
-          },
-          "500": {
-            "description": "Internal error"
-          }
-        },
-        "deprecated": false
-      }
     }
   },
   "definitions": {
@@ -1143,27 +888,27 @@
       "properties": {
         "adjustedBudgetAmount": {
           "type": "number",
-          "description": "The amount adjusted against this budget. **Read only**"
+          "description": "The amount adjusted against this budget. **READ ONLY**"
         },
         "availableAmount": {
           "type": "number",
-          "description": "The available amount accumulated against this budget. Uses budget entity setting to determine which amounts are included to calculate available amount. **Read only**"
+          "description": "The available amount accumulated against this budget. Uses budget entity setting to determine which amounts are included to calculate available amount. **READ ONLY**"
         },
         "consumedPercent": {
           "type": "number",
-          "description": "The percentage of the budget that is considered used. Uses budget entity setting to determine which amounts to include. **Read only**"
+          "description": "The percentage of the budget that is considered used. Uses budget entity setting to determine which amounts to include. **READ ONLY**"
         },
         "pendingAmount": {
           "type": "number",
-          "description": "The pending amount accumulated against this budget. **Read only**"
+          "description": "The pending amount accumulated against this budget. **READ ONLY**"
         },
         "spendAmount": {
           "type": "number",
-          "description": "The spend amount accumulated against this budget. **Read only**"
+          "description": "The spend amount accumulated against this budget. **READ ONLY**"
         },
         "threshold": {
           "type": "string",
-          "description": "The indicator of whether this budget is under the alert limit (UNDER), equal to or over the alert limit, but under the control limit (ALERT), or equal to or over the control limit (OVER). **Read only**",
+          "description": "The indicator of whether this budget is under the alert limit (UNDER), equal to or over the alert limit, but under the control limit (ALERT), or equal to or over the control limit (OVER). **READ ONLY**",
           "enum": [
             "UNDER",
             "ALERT",
@@ -1173,11 +918,11 @@
         },
         "unExpensedAmount": {
           "type": "number",
-          "description": "The pending amount accumulated against this budget. **Read only**"
+          "description": "The pending amount accumulated against this budget. **READ ONLY**"
         },
         "unExpensedSettings": {
           "type": "boolean",
-          "description": "The unexpensed settings is used to decided to show unexpensed balance or not. **Read only**"
+          "description": "The unexpensed settings is used to decided to show unexpensed balance or not. **READ ONLY**"
         }
       },
       "title": "BudgetAmount"
@@ -1334,10 +1079,10 @@
           "type": "string",
           "description": "The alpha currency code, e.g. USD or GBP"
         },
-        "detailDashboardBudgetItemAdjustmentDTOs": {
+        "detailDashboardBudgetItemAdjustments": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DetailDashboardBudgetItemAdjustmentDTO"
+            "$ref": "#/definitions/DetailDashboardBudgetItemAdjustment"
           }
         },
         "fiscalPeriod": {
@@ -1369,7 +1114,7 @@
       "properties": {
         "active": {
           "type": "boolean",
-          "description": "Indicates if this budget should be displayed on user screens **Read only**"
+          "description": "Indicates if this budget should be displayed on user screens **READ ONLY**"
         },
         "annualBudget": {
           "type": "number",
@@ -1439,7 +1184,7 @@
         "createdDate": {
           "type": "string",
           "format": "date-time",
-          "description": "The time the budget item header was created. Field is read only. Date in UTC."
+          "description": "The time the budget item header was created. Date in UTC. **READ ONLY**"
         },
         "currencyCode": {
           "type": "string",
@@ -1470,7 +1215,7 @@
         "lastModifiedDate": {
           "type": "string",
           "format": "date-time",
-          "description": "The last time the budget item header was updated. Field is read only. Date in UTC."
+          "description": "The last time the budget item header was updated. Date in UTC. **READ ONLY**"
         },
         "name": {
           "type": "string",
@@ -1478,7 +1223,7 @@
         },
         "owned": {
           "type": "boolean",
-          "description": "Indicates if this budget is owned by the current user **Read only**"
+          "description": "Indicates if this budget is owned by the current user **READ ONLY**"
         },
         "owner": {
           "description": "The user who is ultimately responsible for this budget. He/she may approve spending for the budget",
@@ -1486,7 +1231,7 @@
         },
         "periodType": {
           "type": "string",
-          "description": "The type of period within the fiscal year that this budget uses **Read only**",
+          "description": "The type of period within the fiscal year that this budget uses **READ ONLY**",
           "enum": [
             "MONTHLY",
             "QUARTERLY",
@@ -1606,7 +1351,7 @@
       },
       "title": "DateRange"
     },
-    "DetailDashboardBudgetItemAdjustmentDTO": {
+    "DetailDashboardBudgetItemAdjustment": {
       "type": "object",
       "required": [
         "amount"
@@ -1663,7 +1408,7 @@
           "description": "The transaction date of adjusted spend. Required when the adjustment is made for amount type SPENT_AMOUNT or PENDING_AMOUNT"
         }
       },
-      "title": "DetailDashboardBudgetItemAdjustmentDTO"
+      "title": "DetailDashboardBudgetItemAdjustment"
     },
     "ExpenseType": {
       "type": "object",
@@ -1812,7 +1557,7 @@
         "lastModified": {
           "type": "string",
           "format": "date-time",
-          "description": "The last time the fiscal year was updated. Field is read only. Date in UTC."
+          "description": "The last time the fiscal year was updated. Date in UTC. **READ ONLY**"
         },
         "monthlyFiscalPeriods": {
           "type": "array",

--- a/src/api-reference/budget/getting-started.md
+++ b/src/api-reference/budget/getting-started.md
@@ -23,7 +23,7 @@ layout: reference
 
 ## <a name="overview"></a>Overview
 
-The Budget service exposes budget and fiscal year data.  Partners may use the service endpoints to read and alter fiscal year, budget, budget adjustment, and budget matching configuration.
+The Budget service exposes budget and fiscal year data.  Partners and clients may use the service endpoints to read and alter fiscal year, budget, budget adjustment, and budget matching configuration.
 Summary and detailed balance amounts are also available to read, but may not be altered via the API.
 
 The sequence to configure budgets is to first setup the fiscal year and then the budget categories (if applicable) before creating budget items. Budget items may use budget tracking fields as filters. The budget tracking field can only be configured in the application UI. Also budget owner, approver, and budget viewer permissions have to be assigned to users prior to configuring budgets.


### PR DESCRIPTION
Removed usage metrics endpoints as they are not meant for external access. Also removed the budget export endpoint, added consistent labeling for READ ONLY properties and corrected other minor issues.