### PR TITLE
Update v3.reports.markdown

### DIFF
--- a/src/api-reference/expense/expense-report/v3.reports.markdown
+++ b/src/api-reference/expense/expense-report/v3.reports.markdown
@@ -46,20 +46,20 @@ Name|Type|Format|Description
 `hasBillableExpenses`|`Boolean`|`query`|The IsBillable flag for at least one expense entry in the report. Format: true or false.
 `isTestUser`|`Boolean`|`query`|The report owner is a test user using the report for testing purposes in a non-production environment. Format: true or false.
 `expenseGroupConfigID`|`string`|`query`|The unique identifier for the expense group configuration associated to the report's expense group. Use the ID from the Response of the Expense Group Configurations V3.
-`entryTransactionDateBefore`|`DateTime`|`query`|The entry transaction date for at least one expense entry in the report is before this date. Format: YYYY-MM-DD
-`entryTransactionDateAfter`|`DateTime`|`query`|The entry transaction date for at least one expense entry in the report is after this date. Format: YYYY-MM-DD
-`createDateBefore`|`DateTime`|`query`|The report create date is before this date. Format: YYYY-MM-DD
-`createDateAfter`|`DateTime`|`query`|The report create date is after this date. Format: YYYY-MM-DD
-`userDefinedDateBefore`|`DateTime`|`query`|The report user defined date is before this date. Format: YYYY-MM-DD
-`userDefinedDateAfter`|`DateTime`|`query`|The report user defined date is after this date. Format: YYYY-MM-DD
-`submitDateBefore`|`DateTime`|`query`|The report submit date is before this date. Format: YYYY-MM-DD
-`submitDateAfter`|`DateTime`|`query`|The report submit date is after this date. Format: YYYY-MM-DD
-`processingPaymentDateBefore`|`DateTime`|`query`|The report processing payment date is before this date. Format: YYYY-MM-DD
-`processingPaymentDateAfter`|`DateTime`|`query`|The report processing payment date is after this date. Format: YYYY-MM-DD
-`paidDateBefore`|`DateTime`|`query`|The report paid date is before this date. Format: YYYY-MM-DD
-`paidDateAfter`|`DateTime`|`query`|The report paid date is after this date. Format: YYYY-MM-DD
-`modifiedDateBefore`|`DateTime`|`query`|The report modified date is before this date. Format: YYYY-MM-DD
-`modifiedDateAfter`|`DateTime`|`query`|The report modified date is after this date. Format: YYYY-MM-DD
+`entryTransactionDateBefore`|`DateTime`|`query`|The entry transaction date for at least one expense entry in the report is before this date. Accepted Formats: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss.SSS
+`entryTransactionDateAfter`|`DateTime`|`query`|The entry transaction date for at least one expense entry in the report is after this date. Accepted Formats: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss.SSS
+`createDateBefore`|`DateTime`|`query`|The report create date is before this date. Accepted Formats: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss.SSS
+`createDateAfter`|`DateTime`|`query`|The report create date is after this date. Accepted Formats: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss.SSS
+`userDefinedDateBefore`|`DateTime`|`query`|The report user defined date is before this date. Accepted Formats: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss.SSS
+`userDefinedDateAfter`|`DateTime`|`query`|The report user defined date is after this date. Accepted Formats: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss.SSS
+`submitDateBefore`|`DateTime`|`query`|The report submit date is before this date. Format: Accepted Formats: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss.SSS
+`submitDateAfter`|`DateTime`|`query`|The report submit date is after this date. Format: Accepted Formats: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss.SSS
+`processingPaymentDateBefore`|`DateTime`|`query`|The report processing payment date is before this date. Accepted Formats: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss.SSS
+`processingPaymentDateAfter`|`DateTime`|`query`|The report processing payment date is after this date. Accepted Formats: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss.SSS
+`paidDateBefore`|`DateTime`|`query`|The report paid date is before this date. Accepted Formats: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss.SSS
+`paidDateAfter`|`DateTime`|`query`|The report paid date is after this date. Accepted Formats: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss.SSS
+`modifiedDateBefore`|`DateTime`|`query`|The report modified date is before this date. Accepted Formats: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss.SSS
+`modifiedDateAfter`|`DateTime`|`query`|The report modified date is after this date. Accepted Formats: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss.SSS
 
 
 ### Request URL
@@ -148,13 +148,12 @@ https://www.concursolutions.com/api/v3.0/expense/reports?limit=15&user=ALL
 Name|Type|Format|Description
 -----|------|--------|------------
 `id`|`string`|`path`|**Required** Report ID
-`user`|`string`|`query`|Optional. The login ID of the report owner(s) to use when searching for reports. If the value is set to LoginID, reports for the report owner with this login ID value are returned. If the value is set to ALL, reports for all report owners are returned. If this parameter is not specified, reports for the OAuth Consumer are returned. The access token owner (OAuth Consumer) must have the Web Services Admin role to use this parameter.
-
+`user`|`string`|`query`|LoginID of the report owner needs to be specified in the query parameter when searching for specific report using ReportID. If Bearer Access token used in the API call is equal to the Bearer access token of the owner of the report, user parameter can be omitted. Parameter equal to ALL (user=ALL) is not allowed when operating on a single resource (single ReportID).
 
 ### Request URL
 
 ```
-https://www.concursolutions.com/api/v3.0/expense/reports/39BD9F7C5C3F4986A6A5
+https://www.concursolutions.com/api/v3.0/expense/reports/39BD9F7C5C3F4986A6A5?user=jimadmin@concurconnect2.com
 ```
 
 ### JSON example of a successful response


### PR DESCRIPTION
Please update documentation of Report V3 based on the proposed pull-request.
user=ALL cannot be used when operating on a single resource (ReportID)
user={owner of the Report} needs to be specified if operating on a single resource, if Report is not owned by user specified via Bearer Access token.
Updated accepted formats of DateTime parameters on GET while Retrieving reports owned by the user based on search criteria

