### PR TITLE
Updated the links to Report v1 and v3

### DIFF
--- a/src/api-reference/expense/expense-report/v4.reports.markdown
+++ b/src/api-reference/expense/expense-report/v4.reports.markdown
@@ -28,8 +28,8 @@ The Reports v4 API can be used to read and modify an expense report header of an
 
 ## Prior Versions
 
-* Report Header v1 (Deprecated) documentation is available [here](./api-reference-deprecated/version-one-one/expense-report/expense-report-header-resource.html)
-* Reports v3 (Deprecated) documentation is available [here](./v3.reports.html)
+* Report Header v1 (Deprecated) documentation is available [here](/api-reference/expense/expense-report/v1dot1.reports.html)
+* Reports v3 (Deprecated) documentation is available [here](/v3.reports.html)
 
 ## <a name="products-editions"></a>Products and Editions
 

--- a/src/api-reference/expense/expense-report/v4.reports.markdown
+++ b/src/api-reference/expense/expense-report/v4.reports.markdown
@@ -28,8 +28,8 @@ The Reports v4 API can be used to read and modify an expense report header of an
 
 ## Prior Versions
 
-* Report Header v1 (Deprecated) documentation is available [here](/api-reference/expense/expense-report/v1dot1.reports.html)
-* Reports v3 (Deprecated) documentation is available [here](/v3.reports.html)
+* Report Header v1 (Deprecated) documentation is available [here](./api-reference/expense/expense-report/v1dot1.reports.html)
+* Reports v3 (Deprecated) documentation is available [here](./v3.reports.html)
 
 ## <a name="products-editions"></a>Products and Editions
 


### PR DESCRIPTION
The links on the current  v4 Reports page end up in a 404 page not found. Modified the links to hopefully ones that actually point to the correct location. @jonikamelcher  please check I  have the correct links.

