### PR TITLE
Update v2.profile-resource.markdown

### DIFF
--- a/src/api-reference/travel-profile/v2.profile-resource.markdown
+++ b/src/api-reference/travel-profile/v2.profile-resource.markdown
@@ -158,7 +158,7 @@ Name|Data Type|Description|Update|Create|Comments
 `CostCenter`|`string`|The user’s cost center. Format: nvarchar(25)|-|-|Requires Company Details scope.
 `CompanyEmployeeID`|`string`|The user’s employee ID. Format: nvarchar(48)|-|-|Requires Company Details scope.  Must be unique in the company.
 `Division`|`string`|The user's division. Format: nvarchar(60)|-|-|Requires Company Details scope.  Must already be setup in the company configuration.
-`PreferredLanguage`|`string`|The user's preferred language locale. Example: United States English is en-US. Format: varchar(20)|-|-|-
+`PreferredLanguage`|`string`|The user's preferred language locale. Example: United States English is en-US. Format: varchar(20)|-|-|See list of allowed canonical values below. Values not on this list will write an empty string|
 `EReceiptOptIn`|`boolean`|Whether the user has opted in to receive e-receipts. Format: true\false|-|-
 `HasOpenBooking`|`boolean`|Whether the user has the TripLink User (formerly Open Booking User) permission. Format: true\false|Cannot Update|-|-
 `CountryCode`|`string`|The country code in from the [ISO 3166-1 alpha-2 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) specification. Format: char(2)|Cannot Update|-|-
@@ -174,6 +174,83 @@ Name|Data Type|Description|Update|Create|Comments
 `UUID`|`string`|The user's Unique Identifier. Format: GUID, 32 characters|Cannot Update|-|Requires TMC Specific scope.
 
 **NOTE**:  If MiddleName is provided, the NoMiddleName flag in TSAInfo section is set to false.
+
+#### Canonical List of Preferred Language Values
+  * "bg"
+  * "cs"
+  * "da"
+  * "de"
+  * "el"
+  * "en"
+  * "es"
+  * "fi"
+  * "fr"
+  * "hr"
+  * "hu"
+  * "id"
+  * "it"
+  * "ja"
+  * "ko"
+  * "nb"
+  * "nl"
+  * "nn"
+  * "no"
+  * "pl"
+  * "pt"
+  * "ro"
+  * "ru"
+  * "sk"
+  * "sv"
+  * "tr"
+  * "zh"
+  * "de-AT"
+  * "de-CH"
+  * "de-DE"
+  * "de-LU"
+  * "en-AU"
+  * "en-CA"
+  * "en-GB"
+  * "en-IE"
+  * "en-IN"
+  * "en-NZ"
+  * "en-US"
+  * "en-ZA"
+  * "es-AR"
+  * "es-BO"
+  * "es-CL"
+  * "es-CO"
+  * "es-CR"
+  * "es-DO"
+  * "es-EC"
+  * "es-ES"
+  * "es-GT"
+  * "es-HN"
+  * "es-MX"
+  * "es-NI"
+  * "es-PA"
+  * "es-PE"
+  * "es-PR"
+  * "es-PY"
+  * "es-SV"
+  * "es-UY"
+  * "es-VE"
+  * "fr-BE"
+  * "fr-CA"
+  * "fr-CH"
+  * "fr-FR"
+  * "fr-LU"
+  * "it-CH"
+  * "it-IT"
+  * "ja-JP"
+  * "nl-BE"
+  * "nl-NL"
+  * "no-NO"
+  * "pt-BR"
+  * "pt-PT"
+  * "sv-SE"
+  * "zh-CN"
+  * "zh-HK"
+  * "zh-TW"
 
 #### <a name="schema-emergency-contact"></a>EmergencyContact
 


### PR DESCRIPTION
Added a list of canonical values for Preferred Language field, along with a note in that field in the table. If you have a suggestion on a better way to format that list, I'm open to suggestions. Note that this is the SAME list that Suhita said she added to the Profilev4 API  - both APIs are enforcing the same set of values. It might make sense to put them on their own page and link both API docs to that page. That way there's only 1 source to maintain. But that might be a bigger project than it's worth given all the other priorities. 