### PR TITLE
TRIPSTORE-3119 - New plural route for geting trip by id endpoint "/trips/:id"

### DIFF
--- a/src/api-explorer/v4-0/Itinerary.swagger2.json
+++ b/src/api-explorer/v4-0/Itinerary.swagger2.json
@@ -14,7 +14,7 @@
       "version": "v4"
   },
   "host": "us.api.concursolutions.com",
-  "basePath": "/travel/trips/api/v4",
+  "basePath": "/travel/v4",
   "produces": [
     "application/json",
     "application/xml"
@@ -23,7 +23,7 @@
     "application/json"
   ],
   "paths": {
-      "/trip/{tripID}": {
+      "/trips/{tripID}": {
           "get": {
               "description": "Gets the trip record",              
               "tags": [

--- a/src/api-guides/travel/duty-of-care.markdown
+++ b/src/api-guides/travel/duty-of-care.markdown
@@ -76,7 +76,7 @@ The following are the different Event Types available:
     "userId": "b7d12989-0489-471a-81cd-175f8b78afa5",
     "companyId": "ab83bc5f-f66e-4ce0-9dcc-7dbf0195e061",
     "hrefs": {
-      "v4": "https://us.api.concursolutions.com/travel/trips/api/v4/trip/51519e89-2c1d-47ec-bd93-7c4ace9c57e6"
+      "v4": "https://us.api.concursolutions.com/travel/v4/trips/51519e89-2c1d-47ec-bd93-7c4ace9c57e6"
     }
   }
 }

--- a/src/api-reference/travel/itinerary-v4/v4.itinerary.md
+++ b/src/api-reference/travel/itinerary-v4/v4.itinerary.md
@@ -63,7 +63,7 @@ Retrieves the record of a trip.
 ##### Template
 
 ```shell
-GET https://{region}.api.concursolutions.com/travel/trips/api/v4/trip/{id}
+GET https://{region}.api.concursolutions.com/travel/v4/trips/{id}
 ```
 
 ##### Parameters
@@ -99,7 +99,7 @@ Name|Type|Format|Description
 #### Request
 
 ```shell
-GET https://us.api.concursolutions.com/travel/trips/api/v4/trip/51519e89-2c1d-47ec-bd93-7c4ace9c57e6
+GET https://us.api.concursolutions.com/travel/v4/trips/51519e89-2c1d-47ec-bd93-7c4ace9c57e6
 Accept: application/json
 Authorization: Bearer <JWT Token>
 ```
@@ -945,7 +945,7 @@ Content-Type: application/json
     "Description": "Trip from somewhere to somewhere else 506643842",
     "EndDateLocal": "2020-12-16T17:15:18.000-00:00",
     "EndDateUtc": "2020-12-17T01:15:18.000+00:00",
-    "id": "https://us.api.concursolutions.com/travel/trips/v4/trip/08d019f6-8c7e-5e96-bbf4-04726ac5def2",
+    "id": "https://us.api.concursolutions.com/travel/v4/trips/08d019f6-8c7e-5e96-bbf4-04726ac5def2",
     "ItinLocator": "gWutRRSrKhRhhY9lx0GUfP1YhfAXDTBtYwFTA$pKU",
     "ProjectName": "Big Project # 43534534",
     "StartDateLocal": "2020-12-11T15:54:18.000-00:00",

--- a/src/event-topics/travel/v4.itinerary-events.md
+++ b/src/event-topics/travel/v4.itinerary-events.md
@@ -74,7 +74,7 @@ Name|Type|Format|Description
     "userId": "b7d12989-0489-471a-81cd-175f8b78afa5",
     "companyId": "ab83bc5f-f66e-4ce0-9dcc-7dbf0195e061",
     "hrefs": {
-      "v4": "https://us.api.concursolutions.com/travel/trips/api/v4/trip/51519e89-2c1d-47ec-bd93-7c4ace9c57e6"
+      "v4": "https://us.api.concursolutions.com/travel/v4/trips/51519e89-2c1d-47ec-bd93-7c4ace9c57e6"
     }
   }
 },


### PR DESCRIPTION
Update endpoint of getting trip by id to `trips/:id` in public event and swagger doc